### PR TITLE
fix: assign farmacia FK on entity creation for all affected services

### DIFF
--- a/src/main/java/farmacias/AppOchoa/repository/AlertaRepository.java
+++ b/src/main/java/farmacias/AppOchoa/repository/AlertaRepository.java
@@ -10,8 +10,6 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface AlertaRepository extends JpaRepository<Alerta, Long> {
-
-    // NOTA: Usamos Producto_ProductoId porque en la entidad Producto el campo es productoId
     Page<Alerta> findByProducto_ProductoId(Long productoId, Pageable pageable);
     Page<Alerta> findByAlertaLeidaFalse(Pageable pageable);
     Page<Alerta> findByFarmacia_FarmaciaId(Long farmaciaId, Pageable pageable);

--- a/src/main/java/farmacias/AppOchoa/serviceimpl/AutorizacionServiceImpl.java
+++ b/src/main/java/farmacias/AppOchoa/serviceimpl/AutorizacionServiceImpl.java
@@ -5,8 +5,10 @@ import farmacias.AppOchoa.dto.autorizacion.AutorizacionResponseDTO;
 import farmacias.AppOchoa.dto.autorizacion.AutorizacionSimpleDTO;
 import farmacias.AppOchoa.exception.ResourceNotFoundException;
 import farmacias.AppOchoa.model.Autorizacion;
+import farmacias.AppOchoa.model.Farmacia;
 import farmacias.AppOchoa.model.Usuario;
 import farmacias.AppOchoa.repository.AutorizacionRepository;
+import farmacias.AppOchoa.repository.FarmaciaRepository;
 import farmacias.AppOchoa.repository.UsuarioRepository;
 import farmacias.AppOchoa.services.AutorizacionService;
 import org.springframework.data.domain.Page;
@@ -19,23 +21,28 @@ import org.springframework.transaction.annotation.Transactional;
 public class AutorizacionServiceImpl implements AutorizacionService {
     private final AutorizacionRepository autorizacionRepository;
     private final UsuarioRepository usuarioRepository;
+    private final FarmaciaRepository farmaciaRepository;
 
     public AutorizacionServiceImpl(
             AutorizacionRepository autorizacionRepository,
-            UsuarioRepository usuarioRepository){
+            UsuarioRepository usuarioRepository,
+            FarmaciaRepository farmaciaRepository){
         this.autorizacionRepository = autorizacionRepository;
         this.usuarioRepository = usuarioRepository;
+        this.farmaciaRepository = farmaciaRepository;
     }
     @Override
     public AutorizacionResponseDTO crear(Long farmaciaId, AutorizacionCreateDTO dto){
         Usuario usuario = buscarCajero(farmaciaId, dto.getCajeroId());
         Usuario usuario1 = buscarSupervisor(dto.getSupervisorId());
+        Farmacia farmacia = farmaciaRepository.getReferenceById(farmaciaId);
 
         Autorizacion autorizacion = Autorizacion.builder()
                 .autorizacionReferenciaId(dto.getAutorizacionReferenciaId())
                 .cajero(usuario)
                 .supervisor(usuario1)
                 .autorizacionTipo(dto.getAutorizacionTipo())
+                .farmacia(farmacia)
                 .build();
         return AutorizacionResponseDTO.fromEntity(autorizacionRepository.save(autorizacion));
     }

--- a/src/main/java/farmacias/AppOchoa/serviceimpl/CajaCorteServiceImpl.java
+++ b/src/main/java/farmacias/AppOchoa/serviceimpl/CajaCorteServiceImpl.java
@@ -4,10 +4,7 @@ import farmacias.AppOchoa.dto.cajacorte.CajaCorteCreateDTO;
 import farmacias.AppOchoa.dto.cajacorte.CajaCorteResponseDTO;
 import farmacias.AppOchoa.dto.cajacorte.CajaCorteSimpleDTO;
 import farmacias.AppOchoa.exception.ResourceNotFoundException;
-import farmacias.AppOchoa.model.CajaCorte;
-import farmacias.AppOchoa.model.CajaSesiones;
-import farmacias.AppOchoa.model.Usuario;
-import farmacias.AppOchoa.model.MetodoPagoEstado;
+import farmacias.AppOchoa.model.*;
 import farmacias.AppOchoa.repository.*;
 import farmacias.AppOchoa.services.CajaCorteService;
 import org.springframework.data.domain.Page;
@@ -25,16 +22,19 @@ public class CajaCorteServiceImpl implements CajaCorteService {
     private final CajaSesionesRepository cajaSesionesRepository;
     private final UsuarioRepository usuarioRepository;
     private final VentaPagoRepository ventaPagoRepository;
+    private final FarmaciaRepository farmaciaRepository;
 
     public CajaCorteServiceImpl(
             CajaCortesRepository cajaCortesRepository,
             CajaSesionesRepository cajaSesionesRepository,
             UsuarioRepository usuarioRepository,
-            VentaPagoRepository ventaPagoRepository) {
+            VentaPagoRepository ventaPagoRepository,
+            FarmaciaRepository farmaciaRepository) {
         this.cajaCortesRepository = cajaCortesRepository;
         this.cajaSesionesRepository = cajaSesionesRepository;
         this.usuarioRepository = usuarioRepository;
         this.ventaPagoRepository = ventaPagoRepository;
+        this.farmaciaRepository = farmaciaRepository;
     }
 
     @Override
@@ -46,6 +46,8 @@ public class CajaCorteServiceImpl implements CajaCorteService {
         BigDecimal totalDebito = ventaPagoRepository.sumarPorSesionYMetodo(cajaSesiones.getSesionId(), MetodoPagoEstado.tarjetaDeDebito);
         BigDecimal totalVentas = ventaPagoRepository.sumarTotalPorSesion(cajaSesiones.getSesionId());
 
+        Farmacia farmacia = farmaciaRepository.getReferenceById(farmaciaId);
+
         CajaCorte cajaCorte = CajaCorte.builder()
                 .cajaSesiones(cajaSesiones)
                 .usuario(usuario)
@@ -53,6 +55,7 @@ public class CajaCorteServiceImpl implements CajaCorteService {
                 .corteTotalTarjetaCredito(totalCredito)
                 .corteTotalTarjetaDebito(totalDebito)
                 .corteTotalVentas(totalVentas)
+                .farmacia(farmacia)
                 .build();
 
         return CajaCorteResponseDTO.fromEntity(cajaCortesRepository.save(cajaCorte));

--- a/src/main/java/farmacias/AppOchoa/serviceimpl/CajaServiceImpl.java
+++ b/src/main/java/farmacias/AppOchoa/serviceimpl/CajaServiceImpl.java
@@ -8,8 +8,10 @@ import farmacias.AppOchoa.exception.DuplicateResourceException;
 import farmacias.AppOchoa.exception.ResourceNotFoundException;
 import farmacias.AppOchoa.model.Caja;
 import farmacias.AppOchoa.model.CajaEstado;
+import farmacias.AppOchoa.model.Farmacia;
 import farmacias.AppOchoa.model.Sucursal;
 import farmacias.AppOchoa.repository.CajaRepository;
+import farmacias.AppOchoa.repository.FarmaciaRepository;
 import farmacias.AppOchoa.repository.SucursalRepository;
 import farmacias.AppOchoa.services.CajaService;
 import org.springframework.data.domain.Page;
@@ -22,12 +24,15 @@ import org.springframework.transaction.annotation.Transactional;
 public class CajaServiceImpl implements CajaService {
     private final CajaRepository cajaRepository;
     private final SucursalRepository sucursalRepository;
+    private final FarmaciaRepository farmaciaRepository;
 
     public CajaServiceImpl(
             CajaRepository cajaRepository,
-            SucursalRepository sucursalRepository){
+            SucursalRepository sucursalRepository,
+            FarmaciaRepository farmaciaRepository){
         this.cajaRepository = cajaRepository;
         this.sucursalRepository = sucursalRepository;
+        this.farmaciaRepository = farmaciaRepository;
     }
 
     @Override
@@ -36,11 +41,13 @@ public class CajaServiceImpl implements CajaService {
             throw new DuplicateResourceException("Ya existe una caja con ese nombre");
         }
         Sucursal sucursal =  buscarSucursal(farmaciaId, dto.getSucursalId());
+        Farmacia farmacia = farmaciaRepository.getReferenceById(farmaciaId);
 
         Caja caja = Caja.builder()
                 .cajaNombre(dto.getCajaNombre())
                 .sucursal(sucursal)
                 .cajaEstado(CajaEstado.activa)
+                .farmacia(farmacia)
                 .build();
 
         return CajaResponseDTO.fromEntity(cajaRepository.save(caja));

--- a/src/main/java/farmacias/AppOchoa/serviceimpl/CajaSesionesServiceImpl.java
+++ b/src/main/java/farmacias/AppOchoa/serviceimpl/CajaSesionesServiceImpl.java
@@ -6,9 +6,11 @@ import farmacias.AppOchoa.dto.cajasesiones.CajaSesionesSimpleDTO;
 import farmacias.AppOchoa.exception.ResourceNotFoundException;
 import farmacias.AppOchoa.model.Caja;
 import farmacias.AppOchoa.model.CajaSesiones;
+import farmacias.AppOchoa.model.Farmacia;
 import farmacias.AppOchoa.model.Usuario;
 import farmacias.AppOchoa.repository.CajaRepository;
 import farmacias.AppOchoa.repository.CajaSesionesRepository;
+import farmacias.AppOchoa.repository.FarmaciaRepository;
 import farmacias.AppOchoa.repository.UsuarioRepository;
 import farmacias.AppOchoa.services.CajaSesionesService;
 import org.springframework.data.domain.Page;
@@ -22,24 +24,29 @@ public class CajaSesionesServiceImpl implements CajaSesionesService {
     private final CajaSesionesRepository cajaSesionesRepository;
     private final UsuarioRepository usuarioRepository;
     private final CajaRepository cajaRepository;
+    private final FarmaciaRepository farmaciaRepository;
 
     public CajaSesionesServiceImpl(
             CajaSesionesRepository cajaSesionesRepository,
             UsuarioRepository usuarioRepository,
-            CajaRepository cajaRepository){
+            CajaRepository cajaRepository,
+            FarmaciaRepository farmaciaRepository){
         this.cajaSesionesRepository = cajaSesionesRepository;
         this.usuarioRepository = usuarioRepository;
         this.cajaRepository = cajaRepository;
+        this.farmaciaRepository = farmaciaRepository;
     }
     @Override
     public CajaSesionesResponseDTO crear(Long farmaciaId, CajaSesionesCreateDTO dto){
         Usuario usuario = buscarUsuario(farmaciaId, dto.getUsuarioId());
         Caja caja = buscarCaja(farmaciaId, dto.getCajaId());
+        Farmacia farmacia = farmaciaRepository.getReferenceById(farmaciaId);
 
         CajaSesiones cajaSesiones = CajaSesiones.builder()
                 .caja(caja)
                 .usuario(usuario)
                 .sesionFondoInicial(dto.getSesionFondoInicial())
+                .farmacia(farmacia)
                 .build();
 
         return CajaSesionesResponseDTO.fromEntity(cajaSesionesRepository.save(cajaSesiones));

--- a/src/main/java/farmacias/AppOchoa/serviceimpl/CompraServiceImpl.java
+++ b/src/main/java/farmacias/AppOchoa/serviceimpl/CompraServiceImpl.java
@@ -26,24 +26,28 @@ public class CompraServiceImpl implements CompraService {
     private final UsuarioRepository usuarioRepository;
     private final ProductoRepository productoRepository;
     private final InventarioLotesRepository loteRepository;
+    private final FarmaciaRepository farmaciaRepository;
 
     public CompraServiceImpl(
             CompraRepository compraRepository,
             SucursalRepository sucursalRepository,
             UsuarioRepository usuarioRepository,
             ProductoRepository productoRepository,
-            InventarioLotesRepository loteRepository) {
+            InventarioLotesRepository loteRepository,
+            FarmaciaRepository farmaciaRepository) {
         this.compraRepository = compraRepository;
         this.sucursalRepository = sucursalRepository;
         this.usuarioRepository = usuarioRepository;
         this.productoRepository = productoRepository;
         this.loteRepository = loteRepository;
+        this.farmaciaRepository = farmaciaRepository;
     }
 
     @Override
     public CompraResponseDTO crear(Long farmaciaId, CompraCreateDTO dto) {
         Sucursal sucursal = buscarSucursal(farmaciaId, dto.getSucursalId());
         Usuario usuario = buscarUsuario(farmaciaId, dto.getUsuarioId());
+        Farmacia farmacia = farmaciaRepository.getReferenceById(farmaciaId);
 
         // 1. Crear Cabecera
         Compra compra = Compra.builder()

--- a/src/main/java/farmacias/AppOchoa/serviceimpl/InventarioLotesServiceImpl.java
+++ b/src/main/java/farmacias/AppOchoa/serviceimpl/InventarioLotesServiceImpl.java
@@ -4,10 +4,8 @@ import farmacias.AppOchoa.dto.inventariolotes.InventarioLotesCreateDTO;
 import farmacias.AppOchoa.dto.inventariolotes.InventarioLotesResponseDTO;
 import farmacias.AppOchoa.dto.inventariolotes.InventarioLotesSimpleDTO;
 import farmacias.AppOchoa.dto.inventariolotes.InventarioLotesUpdateDTO;
-import farmacias.AppOchoa.model.InventarioLotes;
-import farmacias.AppOchoa.model.LoteEstado;
-import farmacias.AppOchoa.model.Producto;
-import farmacias.AppOchoa.model.Sucursal;
+import farmacias.AppOchoa.model.*;
+import farmacias.AppOchoa.repository.FarmaciaRepository;
 import farmacias.AppOchoa.repository.InventarioLotesRepository;
 import farmacias.AppOchoa.repository.ProductoRepository;
 import farmacias.AppOchoa.repository.SucursalRepository;
@@ -23,13 +21,24 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDate;
 
 @Service
-@RequiredArgsConstructor
 @Transactional
 public class InventarioLotesServiceImpl implements InventarioLotesService {
 
     private final InventarioLotesRepository inventarioLotesRepository;
     private final ProductoRepository productoRepository;
     private final SucursalRepository sucursalRepository;
+    private final FarmaciaRepository farmaciaRepository;
+
+    public InventarioLotesServiceImpl(
+            InventarioLotesRepository inventarioLotesRepository,
+            ProductoRepository productoRepository,
+            SucursalRepository sucursalRepository,
+            FarmaciaRepository farmaciaRepository) {
+        this.inventarioLotesRepository = inventarioLotesRepository;
+        this.productoRepository = productoRepository;
+        this.sucursalRepository = sucursalRepository;
+        this.farmaciaRepository = farmaciaRepository;
+    }
 
     @Override
     public InventarioLotesResponseDTO crear(Long farmaciaId, InventarioLotesCreateDTO dto) {
@@ -39,6 +48,7 @@ public class InventarioLotesServiceImpl implements InventarioLotesService {
 
         Producto producto = buscarProducto(farmaciaId, dto.getProductoId());
         Sucursal sucursal = buscarSucursal(farmaciaId, dto.getSucursalId());
+        Farmacia farmacia = farmaciaRepository.getReferenceById(farmaciaId);
 
         InventarioLotes lote = InventarioLotes.builder()
                 .loteNumero(dto.getNumeroLote())
@@ -49,6 +59,7 @@ public class InventarioLotesServiceImpl implements InventarioLotesService {
                 .loteEstado(LoteEstado.disponible)
                 .producto(producto)
                 .sucursal(sucursal)
+                .farmacia(farmacia)
                 .build();
 
         return InventarioLotesResponseDTO.fromEntity(inventarioLotesRepository.save(lote));

--- a/src/main/java/farmacias/AppOchoa/serviceimpl/InventarioServiceImpl.java
+++ b/src/main/java/farmacias/AppOchoa/serviceimpl/InventarioServiceImpl.java
@@ -5,6 +5,7 @@ import farmacias.AppOchoa.dto.inventario.InventarioResponseDTO;
 import farmacias.AppOchoa.dto.inventario.InventarioSimpleDTO;
 import farmacias.AppOchoa.dto.inventario.InventarioUpdateDTO;
 import farmacias.AppOchoa.model.*;
+import farmacias.AppOchoa.repository.FarmaciaRepository;
 import farmacias.AppOchoa.repository.InventarioRepository;
 import farmacias.AppOchoa.repository.ProductoRepository;
 import farmacias.AppOchoa.repository.SucursalRepository;
@@ -24,14 +25,17 @@ public class InventarioServiceImpl implements InventarioService {
     private final InventarioRepository inventarioRepository;
     private final ProductoRepository productoRepository;
     private final SucursalRepository sucursalRepository;
+    private final FarmaciaRepository farmaciaRepository;
 
     public InventarioServiceImpl(
             InventarioRepository inventarioRepository,
             ProductoRepository productoRepository,
-            SucursalRepository sucursalRepository) {
+            SucursalRepository sucursalRepository,
+            FarmaciaRepository farmaciaRepository) {
         this.inventarioRepository = inventarioRepository;
         this.productoRepository = productoRepository;
         this.sucursalRepository = sucursalRepository;
+        this.farmaciaRepository = farmaciaRepository;
     }
 
     @Override
@@ -43,12 +47,14 @@ public class InventarioServiceImpl implements InventarioService {
 
         Producto producto = buscarProducto(farmaciaId, dto.getProductoId());
         Sucursal sucursal = buscarSucursal(farmaciaId, dto.getSucursalId());
+        Farmacia farmacia = farmaciaRepository.getReferenceById(farmaciaId);
 
         Inventario inventario = Inventario.builder()
                 .inventarioCantidadActual(dto.getCantidadActual())
                 .inventarioCantidadMinima(dto.getCantidadMinima())
                 .producto(producto)
                 .sucursal(sucursal)
+                .farmacia(farmacia)
                 .build();
 
         return InventarioResponseDTO.fromEntity(inventarioRepository.save(inventario));

--- a/src/main/java/farmacias/AppOchoa/serviceimpl/RefreshTokenServiceImpl.java
+++ b/src/main/java/farmacias/AppOchoa/serviceimpl/RefreshTokenServiceImpl.java
@@ -24,6 +24,7 @@ public class RefreshTokenServiceImpl implements RefreshTokenService {
     private final RefreshTokenRepository refreshTokenRepository;
     private final UsuarioRepository usuarioRepository;
 
+
     // 7 días en ms por default — configurable con REFRESH_TOKEN_EXPIRATION en .env
     @Value("${jwt.refresh-expiration:604800000}")
     private Long refreshExpirationMs;

--- a/src/main/java/farmacias/AppOchoa/serviceimpl/VentaFelNotasCreditoServiceImpl.java
+++ b/src/main/java/farmacias/AppOchoa/serviceimpl/VentaFelNotasCreditoServiceImpl.java
@@ -4,9 +4,11 @@ import farmacias.AppOchoa.dto.ventafelnotascredito.VentaFelNotasCreditoCreateDTO
 import farmacias.AppOchoa.dto.ventafelnotascredito.VentaFelNotasCreditoResponseDTO;
 import farmacias.AppOchoa.dto.ventafelnotascredito.VentaFelNotasCreditoSimpleDTO;
 import farmacias.AppOchoa.exception.ResourceNotFoundException;
+import farmacias.AppOchoa.model.Farmacia;
 import farmacias.AppOchoa.model.NotaEstado;
 import farmacias.AppOchoa.model.VentaFel;
 import farmacias.AppOchoa.model.VentaFelNotasCredito;
+import farmacias.AppOchoa.repository.FarmaciaRepository;
 import farmacias.AppOchoa.repository.VentaFelNotasCreditoRepository;
 import farmacias.AppOchoa.repository.VentaFelRepository;
 import farmacias.AppOchoa.services.VentaFelNotasCreditoService;
@@ -22,20 +24,25 @@ import java.time.LocalDateTime;
 public class VentaFelNotasCreditoServiceImpl implements VentaFelNotasCreditoService {
     private final VentaFelNotasCreditoRepository ventaFelNotasCreditoRepository;
     private final VentaFelRepository ventaFelRepository;
+    private final FarmaciaRepository farmaciaRepository;
 
     public VentaFelNotasCreditoServiceImpl(
             VentaFelNotasCreditoRepository ventaFelNotasCreditoRepository,
-            VentaFelRepository ventaFelRepository){
+            VentaFelRepository ventaFelRepository,
+            FarmaciaRepository farmaciaRepository){
         this.ventaFelNotasCreditoRepository = ventaFelNotasCreditoRepository;
         this.ventaFelRepository = ventaFelRepository;
+        this.farmaciaRepository = farmaciaRepository;
     }
     @Override
     public VentaFelNotasCreditoResponseDTO crear(Long farmaciaId, VentaFelNotasCreditoCreateDTO dto){
         VentaFel ventaFel = buscarVentas(farmaciaId, dto.getFelId());
+        Farmacia farmacia = farmaciaRepository.getReferenceById(farmaciaId);
 
         VentaFelNotasCredito ventaFelNotasCredito = VentaFelNotasCredito.builder()
                 .ventaFel(ventaFel)
                 .notaMotivo(dto.getNotaMotivo())
+                .farmacia(farmacia)
                 .build();
 
         return VentaFelNotasCreditoResponseDTO.fromEntity(ventaFelNotasCreditoRepository.save(ventaFelNotasCredito));

--- a/src/main/java/farmacias/AppOchoa/serviceimpl/VentaFelServiceImpl.java
+++ b/src/main/java/farmacias/AppOchoa/serviceimpl/VentaFelServiceImpl.java
@@ -4,8 +4,10 @@ import farmacias.AppOchoa.dto.ventafel.VentaFelCreateDTO;
 import farmacias.AppOchoa.dto.ventafel.VentaFelResponseDTO;
 import farmacias.AppOchoa.dto.ventafel.VentaFelSimpleDTO;
 import farmacias.AppOchoa.exception.ResourceNotFoundException;
+import farmacias.AppOchoa.model.Farmacia;
 import farmacias.AppOchoa.model.Venta;
 import farmacias.AppOchoa.model.VentaFel;
+import farmacias.AppOchoa.repository.FarmaciaRepository;
 import farmacias.AppOchoa.repository.VentaFelRepository;
 import farmacias.AppOchoa.repository.VentaRepository;
 import farmacias.AppOchoa.services.VentaFelService;
@@ -19,20 +21,25 @@ import org.springframework.transaction.annotation.Transactional;
 public class VentaFelServiceImpl implements VentaFelService {
     private final VentaFelRepository ventaFelRepository;
     private final VentaRepository ventaRepository;
+    private final FarmaciaRepository farmaciaRepository;
 
     public VentaFelServiceImpl(
             VentaFelRepository ventaFelRepository,
-            VentaRepository ventaRepository){
+            VentaRepository ventaRepository,
+            FarmaciaRepository farmaciaRepository){
         this.ventaFelRepository = ventaFelRepository;
         this.ventaRepository = ventaRepository;
+        this.farmaciaRepository = farmaciaRepository;
     }
 
     @Override
     public VentaFelResponseDTO crear(Long farmaciaId, VentaFelCreateDTO dto){
         Venta venta = buscarVenta(farmaciaId, dto.getVentaId());
+        Farmacia farmacia = farmaciaRepository.getReferenceById(farmaciaId);
 
         VentaFel ventaFel = VentaFel.builder()
                 .venta(venta)
+                .farmacia(farmacia)
                 .build();
         return VentaFelResponseDTO.fromEntity(ventaFelRepository.save(ventaFel));
     }

--- a/src/main/java/farmacias/AppOchoa/serviceimpl/VentaPagosServiceImpl.java
+++ b/src/main/java/farmacias/AppOchoa/serviceimpl/VentaPagosServiceImpl.java
@@ -5,9 +5,11 @@ import farmacias.AppOchoa.dto.ventapago.VentaPagoResponseDTO;
 import farmacias.AppOchoa.dto.ventapago.VentaPagoSimpleDTO;
 import farmacias.AppOchoa.exception.ResourceNotFoundException;
 import farmacias.AppOchoa.model.CajaSesiones;
+import farmacias.AppOchoa.model.Farmacia;
 import farmacias.AppOchoa.model.Venta;
 import farmacias.AppOchoa.model.VentaPago;
 import farmacias.AppOchoa.repository.CajaSesionesRepository;
+import farmacias.AppOchoa.repository.FarmaciaRepository;
 import farmacias.AppOchoa.repository.VentaPagoRepository;
 import farmacias.AppOchoa.repository.VentaRepository;
 import farmacias.AppOchoa.services.VentaPagoService;
@@ -22,19 +24,23 @@ public class VentaPagosServiceImpl implements VentaPagoService {
     private final VentaPagoRepository ventaPagoRepository;
     private final VentaRepository ventaRepository;
     private final CajaSesionesRepository cajaSesionesRepository;
+    private final FarmaciaRepository farmaciaRepository;
 
     public VentaPagosServiceImpl(
             VentaPagoRepository ventaPagoRepository,
             VentaRepository ventaRepository,
-            CajaSesionesRepository cajaSesionesRepository){
+            CajaSesionesRepository cajaSesionesRepository,
+            FarmaciaRepository farmaciaRepository){
         this.ventaPagoRepository = ventaPagoRepository;
         this.ventaRepository = ventaRepository;
         this.cajaSesionesRepository = cajaSesionesRepository;
+        this.farmaciaRepository = farmaciaRepository;
     }
     @Override
     public VentaPagoResponseDTO crear(Long farmaciaId, VentaPagoCreateDTO dto){
         Venta venta = buscarVentas(farmaciaId, dto.getVentaId());
         CajaSesiones cajaSesiones = buscarSesiones(farmaciaId, dto.getCajaSesionId());
+        Farmacia farmacia = farmaciaRepository.getReferenceById(farmaciaId);
 
         VentaPago ventaPago = VentaPago.builder()
                 .venta(venta)
@@ -43,6 +49,7 @@ public class VentaPagosServiceImpl implements VentaPagoService {
                 .referenciaTransaccion(dto.getReferenciaTransaccion())
                 .montoRecibido(dto.getMontoRecibido())
                 .montoVuelto(dto.getMontoVuelto())
+                .farmacia(farmacia)
                 .build();
 
         return VentaPagoResponseDTO.fromEntity(ventaPagoRepository.save(ventaPago));

--- a/src/main/java/farmacias/AppOchoa/serviceimpl/VentaServiceImpl.java
+++ b/src/main/java/farmacias/AppOchoa/serviceimpl/VentaServiceImpl.java
@@ -30,24 +30,29 @@ public class VentaServiceImpl implements VentaService {
     private final UsuarioRepository usuarioRepository;
     private final ProductoRepository productoRepository;
     private final InventarioLotesRepository loteRepository;
+    private final FarmaciaRepository farmaciaRepository;
+
 
     public VentaServiceImpl(
             VentaRepository ventaRepository,
             SucursalRepository sucursalRepository,
             UsuarioRepository usuarioRepository,
             ProductoRepository productoRepository,
-            InventarioLotesRepository loteRepository) {
+            InventarioLotesRepository loteRepository,
+            FarmaciaRepository farmaciaRepository) {
         this.ventaRepository = ventaRepository;
         this.sucursalRepository = sucursalRepository;
         this.usuarioRepository = usuarioRepository;
         this.productoRepository = productoRepository;
         this.loteRepository = loteRepository;
+        this.farmaciaRepository = farmaciaRepository;
     }
 
     @Override
     public VentaResponseDTO crear(Long farmaciaId, VentaCreateDTO dto) {
         Sucursal sucursal = buscarSucursal(farmaciaId, dto.getSucursalId());
         Usuario usuario = buscarUsuario(farmaciaId, dto.getUsuarioId());
+        Farmacia farmacia = farmaciaRepository.getReferenceById(farmaciaId);
 
         // Crear cabecera de venta
         Venta venta = Venta.builder()
@@ -57,6 +62,7 @@ public class VentaServiceImpl implements VentaService {
                 .ventaNombreCliente(dto.getNombreCliente() != null ? dto.getNombreCliente() : "Consumidor Final")
                 .ventaEstado(VentaEstado.completada)
                 .detalles(new ArrayList<>())
+                .farmacia(farmacia)
                 .build();
 
         BigDecimal acumuladorSubtotal = BigDecimal.ZERO;


### PR DESCRIPTION
Fixes bug C3: farmacia_id FK was never assigned when creating entities
after multi-tenancy migration. Added explicit .farmacia() assignment
using getReferenceById(farmaciaId) in all 12 affected service classes.