### PR TITLE
fix(security): enforcement de vigencia de suscripcion en login y filt…

### DIFF
--- a/src/main/java/farmacias/AppOchoa/config/JwtAuthenticationFilter.java
+++ b/src/main/java/farmacias/AppOchoa/config/JwtAuthenticationFilter.java
@@ -1,8 +1,10 @@
 package farmacias.AppOchoa.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import farmacias.AppOchoa.exception.SuscripcionVencidaException;
 import farmacias.AppOchoa.model.Usuario;
 import farmacias.AppOchoa.util.JwtUtil;
+import farmacias.AppOchoa.util.SuscripcionValidator;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.MalformedJwtException;
 import io.jsonwebtoken.security.SignatureException;
@@ -94,6 +96,15 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             if (!usuario.isEnabled()) {
                 log.warn("[JWT] Usuario desactivado intentó acceder a {}: {}", request.getRequestURI(), username);
                 escribirErrorJson(response, HttpStatus.UNAUTHORIZED, "La cuenta está desactivada. Contacta al administrador.");
+                return;
+            }
+
+            // Farmacia desactivada o vencida: rechazar aunque el token siga siendo válido (A8)
+            try {
+                SuscripcionValidator.validarVigencia(usuario.getFarmacia());
+            } catch (SuscripcionVencidaException e) {
+                log.warn("[JWT] Farmacia sin suscripción vigente intentó acceder a {}: {}", request.getRequestURI(), username);
+                escribirErrorJson(response, HttpStatus.UNAUTHORIZED, e.getMessage());
                 return;
             }
 

--- a/src/main/java/farmacias/AppOchoa/controller/FarmaciaController.java
+++ b/src/main/java/farmacias/AppOchoa/controller/FarmaciaController.java
@@ -3,6 +3,7 @@ package farmacias.AppOchoa.controller;
 import farmacias.AppOchoa.dto.farmacia.FarmaciaCreateDTO;
 import farmacias.AppOchoa.dto.farmacia.FarmaciaResponseDTO;
 import farmacias.AppOchoa.dto.farmacia.FarmaciaSimpleDTO;
+import farmacias.AppOchoa.dto.farmacia.SuscripcionRenovarDTO;
 import farmacias.AppOchoa.services.FarmaciaService;
 import jakarta.validation.Valid;
 import lombok.AllArgsConstructor;
@@ -49,6 +50,14 @@ public class FarmaciaController extends  BaseController{
     public ResponseEntity<FarmaciaResponseDTO> crear(@Valid @RequestBody FarmaciaCreateDTO dto){
         FarmaciaResponseDTO farmaciaResponseDTO = farmaciaService.crear(dto);
         return ResponseEntity.status(HttpStatus.CREATED).body(farmaciaResponseDTO);
+    }
+
+    @PatchMapping("/{id}/suscripcion")
+    @PreAuthorize("hasAuthority('superadmin')")
+    public ResponseEntity<FarmaciaResponseDTO> renovarSuscripcion(
+            @PathVariable Long id,
+            @Valid @RequestBody SuscripcionRenovarDTO dto){
+        return ResponseEntity.ok(farmaciaService.renovarSuscripcion(id, dto));
     }
 
     @DeleteMapping("/{id}")

--- a/src/main/java/farmacias/AppOchoa/dto/farmacia/SuscripcionRenovarDTO.java
+++ b/src/main/java/farmacias/AppOchoa/dto/farmacia/SuscripcionRenovarDTO.java
@@ -1,0 +1,19 @@
+package farmacias.AppOchoa.dto.farmacia;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class SuscripcionRenovarDTO {
+
+    @NotNull(message = "La nueva vigencia de la suscripción es obligatoria")
+    private LocalDate nuevaVigencia;
+}

--- a/src/main/java/farmacias/AppOchoa/exception/GlobalExceptionHandler.java
+++ b/src/main/java/farmacias/AppOchoa/exception/GlobalExceptionHandler.java
@@ -33,6 +33,11 @@ public class GlobalExceptionHandler {
         return construirRespuesta(HttpStatus.UNAUTHORIZED, "Usuario o contraseña incorrectos", request);
     }
 
+    @ExceptionHandler(SuscripcionVencidaException.class)
+    public ResponseEntity<Object> manejarSuscripcionVencida(SuscripcionVencidaException ex, WebRequest request) {
+        return construirRespuesta(HttpStatus.UNAUTHORIZED, ex.getMessage(), request);
+    }
+
     @ExceptionHandler(DisabledException.class)
     public ResponseEntity<Object> manejarUsuarioDesactivado(DisabledException ex, WebRequest request) {
         return construirRespuesta(HttpStatus.UNAUTHORIZED, "La cuenta de usuario está desactivada", request);

--- a/src/main/java/farmacias/AppOchoa/exception/SuscripcionVencidaException.java
+++ b/src/main/java/farmacias/AppOchoa/exception/SuscripcionVencidaException.java
@@ -1,0 +1,11 @@
+package farmacias.AppOchoa.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.UNAUTHORIZED)
+public class SuscripcionVencidaException extends RuntimeException { //ERROR 401
+    public SuscripcionVencidaException(String mensaje) {
+        super(mensaje);
+    }
+}

--- a/src/main/java/farmacias/AppOchoa/repository/UsuarioRepository.java
+++ b/src/main/java/farmacias/AppOchoa/repository/UsuarioRepository.java
@@ -3,6 +3,7 @@ package farmacias.AppOchoa.repository;
 import farmacias.AppOchoa.model.Usuario;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -12,6 +13,10 @@ import java.util.Optional;
 public interface UsuarioRepository extends JpaRepository<Usuario, Long> {
 
     boolean existsByNombreUsuarioUsuario(String nombreUsuarioUsuario);
+
+    // Carga farmacia en la misma query: el login y el filtro JWT validan la
+    // vigencia de la suscripción fuera de la sesión de Hibernate (open-in-view: false)
+    @EntityGraph(attributePaths = "farmacia")
     Optional<Usuario> findByNombreUsuarioUsuario(String nombreUsuarioUsuario);
     Page<Usuario> findByUsuarioEstadoTrue(Pageable pageable);
     Page<Usuario> findByFarmacia_FarmaciaIdAndUsuarioEstadoTrue(Long farmaciaId, Pageable pageable);

--- a/src/main/java/farmacias/AppOchoa/serviceimpl/AuthServiceImpl.java
+++ b/src/main/java/farmacias/AppOchoa/serviceimpl/AuthServiceImpl.java
@@ -5,6 +5,7 @@ import farmacias.AppOchoa.model.RefreshToken;
 import farmacias.AppOchoa.model.Usuario;
 import farmacias.AppOchoa.services.AuthService;
 import farmacias.AppOchoa.util.JwtUtil;
+import farmacias.AppOchoa.util.SuscripcionValidator;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -41,6 +42,9 @@ public class AuthServiceImpl implements AuthService {
         );
 
         Usuario usuario = (Usuario) auth.getPrincipal();
+
+        // A8: no emitir token si la farmacia está desactivada o vencida
+        SuscripcionValidator.validarVigencia(usuario.getFarmacia());
 
         Map<String, Object> claims = new HashMap<>();
         claims.put("userId", usuario.getUsuarioId());

--- a/src/main/java/farmacias/AppOchoa/serviceimpl/FarmaciaServiceImpl.java
+++ b/src/main/java/farmacias/AppOchoa/serviceimpl/FarmaciaServiceImpl.java
@@ -3,6 +3,7 @@ package farmacias.AppOchoa.serviceimpl;
 import farmacias.AppOchoa.dto.farmacia.FarmaciaCreateDTO;
 import farmacias.AppOchoa.dto.farmacia.FarmaciaResponseDTO;
 import farmacias.AppOchoa.dto.farmacia.FarmaciaSimpleDTO;
+import farmacias.AppOchoa.dto.farmacia.SuscripcionRenovarDTO;
 import farmacias.AppOchoa.exception.DuplicateResourceException;
 import farmacias.AppOchoa.exception.ResourceNotFoundException;
 import farmacias.AppOchoa.model.Farmacia;
@@ -82,6 +83,18 @@ public class FarmaciaServiceImpl implements FarmaciaService {
     public Page<FarmaciaSimpleDTO> buscarPorTexto(String texto, Pageable pageable){
         return farmaciaRepository.buscarPorTexto(texto, pageable)
                 .map(FarmaciaSimpleDTO::fromEntity);
+    }
+
+    @Override
+    public FarmaciaResponseDTO renovarSuscripcion(Long id, SuscripcionRenovarDTO dto){
+        Farmacia farmacia = farmaciaRepository.findById(id)
+                .orElseThrow(() -> new ResourceNotFoundException("Farmacia no encontrada ID: " + id));
+
+        farmacia.setSuscripcionVigencia(dto.getNuevaVigencia());
+        farmacia.setEnPeriodoPrueba(false);
+        farmacia.setFarmaciaActiva(true);
+
+        return FarmaciaResponseDTO.fromEntity(farmaciaRepository.save(farmacia));
     }
 
     @Override

--- a/src/main/java/farmacias/AppOchoa/services/FarmaciaService.java
+++ b/src/main/java/farmacias/AppOchoa/services/FarmaciaService.java
@@ -3,6 +3,7 @@ package farmacias.AppOchoa.services;
 import farmacias.AppOchoa.dto.farmacia.FarmaciaCreateDTO;
 import farmacias.AppOchoa.dto.farmacia.FarmaciaResponseDTO;
 import farmacias.AppOchoa.dto.farmacia.FarmaciaSimpleDTO;
+import farmacias.AppOchoa.dto.farmacia.SuscripcionRenovarDTO;
 import farmacias.AppOchoa.model.Farmacia;
 import farmacias.AppOchoa.repository.FarmaciaRepository;
 import org.springframework.data.domain.Page;
@@ -14,5 +15,6 @@ public interface FarmaciaService {
     Page<FarmaciaSimpleDTO> listarFarmacias(Pageable pageable);
     void eliminar(Long id);
     Page<FarmaciaSimpleDTO> buscarPorTexto(String texto, Pageable pageable);
+    FarmaciaResponseDTO renovarSuscripcion(Long id, SuscripcionRenovarDTO dto);
 
 }

--- a/src/main/java/farmacias/AppOchoa/util/SuscripcionValidator.java
+++ b/src/main/java/farmacias/AppOchoa/util/SuscripcionValidator.java
@@ -1,0 +1,36 @@
+package farmacias.AppOchoa.util;
+
+import farmacias.AppOchoa.exception.SuscripcionVencidaException;
+import farmacias.AppOchoa.model.Farmacia;
+
+import java.time.LocalDate;
+
+/**
+ * Valida que la farmacia esté activa y con suscripción/periodo de prueba vigente (A8).
+ * Se usa tanto en el login como en el filtro JWT para que un token emitido antes
+ * del vencimiento deje de servir cuando la suscripción caduca.
+ */
+public final class SuscripcionValidator {
+
+    private SuscripcionValidator() {
+    }
+
+    public static void validarVigencia(Farmacia farmacia) {
+        if (Boolean.FALSE.equals(farmacia.getFarmaciaActiva())) {
+            throw new SuscripcionVencidaException("Tu farmacia está desactivada. Contacta al administrador del sistema.");
+        }
+
+        LocalDate hoy = LocalDate.now();
+
+        // Fecha null = sin límite, no se bloquea
+        if (Boolean.TRUE.equals(farmacia.getEnPeriodoPrueba())) {
+            if (farmacia.getPruebaHasta() != null && farmacia.getPruebaHasta().isBefore(hoy)) {
+                throw new SuscripcionVencidaException("Tu periodo de prueba ha vencido. Contacta al administrador del sistema.");
+            }
+        } else {
+            if (farmacia.getSuscripcionVigencia() != null && farmacia.getSuscripcionVigencia().isBefore(hoy)) {
+                throw new SuscripcionVencidaException("Tu suscripción ha vencido. Contacta al administrador del sistema.");
+            }
+        }
+    }
+}

--- a/src/test/java/farmacias/AppOchoa/serviceImplTes/AuthServiceImplTest.java
+++ b/src/test/java/farmacias/AppOchoa/serviceImplTes/AuthServiceImplTest.java
@@ -1,0 +1,167 @@
+package farmacias.AppOchoa.serviceImplTes;
+
+import farmacias.AppOchoa.config.JwtConfig;
+import farmacias.AppOchoa.exception.SuscripcionVencidaException;
+import farmacias.AppOchoa.model.Farmacia;
+import farmacias.AppOchoa.model.RefreshToken;
+import farmacias.AppOchoa.model.Usuario;
+import farmacias.AppOchoa.model.UsuarioRol;
+import farmacias.AppOchoa.serviceimpl.AuthServiceImpl;
+import farmacias.AppOchoa.serviceimpl.RefreshTokenServiceImpl;
+import farmacias.AppOchoa.util.JwtUtil;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+
+import java.time.LocalDate;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class AuthServiceImplTest {
+
+    @Mock
+    private AuthenticationManager authenticationManager;
+    @Mock
+    private JwtUtil jwtUtil;
+    @Mock
+    private JwtConfig jwtConfig;
+    @Mock
+    private RefreshTokenServiceImpl refreshTokenService;
+    @InjectMocks
+    private AuthServiceImpl authService;
+
+    private Usuario crearUsuarioConFarmacia(Farmacia farmacia) {
+        Usuario usuario = new Usuario();
+        usuario.setUsuarioId(1L);
+        usuario.setNombreUsuarioUsuario("jperez");
+        usuario.setUsuarioNombre("Juan");
+        usuario.setUsuarioApellido("Perez");
+        usuario.setUsuarioRol(UsuarioRol.administrador);
+        usuario.setUsuarioEstado(true);
+        usuario.setFarmacia(farmacia);
+        return usuario;
+    }
+
+    private void mockAutenticacion(Usuario usuario) {
+        Authentication auth = new UsernamePasswordAuthenticationToken(usuario, null, usuario.getAuthorities());
+        when(authenticationManager.authenticate(any(UsernamePasswordAuthenticationToken.class)))
+                .thenReturn(auth);
+    }
+
+    @Test
+    @DisplayName("Deberia rechazar el login si la suscripcion de la farmacia ya vencio")
+    void loginConSuscripcionVencida() {
+        Farmacia farmacia = new Farmacia();
+        farmacia.setFarmaciaId(1L);
+        farmacia.setFarmaciaActiva(true);
+        farmacia.setEnPeriodoPrueba(false);
+        farmacia.setSuscripcionVigencia(LocalDate.now().minusDays(1));
+
+        mockAutenticacion(crearUsuarioConFarmacia(farmacia));
+
+        SuscripcionVencidaException ex = assertThrows(SuscripcionVencidaException.class,
+                () -> authService.login("jperez", "secreta123"));
+
+        assertEquals("Tu suscripción ha vencido. Contacta al administrador del sistema.", ex.getMessage());
+        verify(jwtUtil, never()).generateToken(anyMap(), anyString());
+        verify(refreshTokenService, never()).crear(anyLong());
+    }
+
+    @Test
+    @DisplayName("Deberia rechazar el login si el periodo de prueba ya vencio")
+    void loginConPeriodoPruebaVencido() {
+        Farmacia farmacia = new Farmacia();
+        farmacia.setFarmaciaId(1L);
+        farmacia.setFarmaciaActiva(true);
+        farmacia.setEnPeriodoPrueba(true);
+        farmacia.setPruebaHasta(LocalDate.now().minusDays(1));
+
+        mockAutenticacion(crearUsuarioConFarmacia(farmacia));
+
+        SuscripcionVencidaException ex = assertThrows(SuscripcionVencidaException.class,
+                () -> authService.login("jperez", "secreta123"));
+
+        assertEquals("Tu periodo de prueba ha vencido. Contacta al administrador del sistema.", ex.getMessage());
+        verify(jwtUtil, never()).generateToken(anyMap(), anyString());
+    }
+
+    @Test
+    @DisplayName("Deberia rechazar el login si la farmacia esta desactivada")
+    void loginConFarmaciaDesactivada() {
+        Farmacia farmacia = new Farmacia();
+        farmacia.setFarmaciaId(1L);
+        farmacia.setFarmaciaActiva(false);
+
+        mockAutenticacion(crearUsuarioConFarmacia(farmacia));
+
+        SuscripcionVencidaException ex = assertThrows(SuscripcionVencidaException.class,
+                () -> authService.login("jperez", "secreta123"));
+
+        assertEquals("Tu farmacia está desactivada. Contacta al administrador del sistema.", ex.getMessage());
+        verify(jwtUtil, never()).generateToken(anyMap(), anyString());
+    }
+
+    @Test
+    @DisplayName("Deberia permitir el login si la suscripcion no tiene fecha limite (null)")
+    void loginConVigenciaNullNoBloquea() {
+        Farmacia farmacia = new Farmacia();
+        farmacia.setFarmaciaId(1L);
+        farmacia.setFarmaciaActiva(true);
+        farmacia.setEnPeriodoPrueba(false);
+        farmacia.setSuscripcionVigencia(null);
+
+        Usuario usuario = crearUsuarioConFarmacia(farmacia);
+        mockAutenticacion(usuario);
+
+        when(jwtUtil.generateToken(anyMap(), anyString())).thenReturn("token-jwt");
+        RefreshToken refreshToken = new RefreshToken();
+        refreshToken.setToken("refresh-uuid");
+        when(refreshTokenService.crear(1L)).thenReturn(refreshToken);
+        when(jwtConfig.getExpiration()).thenReturn(3600000L);
+
+        Map<String, Object> resultado = authService.login("jperez", "secreta123");
+
+        assertNotNull(resultado);
+        assertEquals("token-jwt", resultado.get("token"));
+        assertEquals("refresh-uuid", resultado.get("refreshToken"));
+    }
+
+    @Test
+    @DisplayName("Deberia permitir el login con suscripcion vigente")
+    void loginConSuscripcionVigente() {
+        Farmacia farmacia = new Farmacia();
+        farmacia.setFarmaciaId(1L);
+        farmacia.setFarmaciaActiva(true);
+        farmacia.setEnPeriodoPrueba(false);
+        farmacia.setSuscripcionVigencia(LocalDate.now().plusMonths(1));
+
+        Usuario usuario = crearUsuarioConFarmacia(farmacia);
+        mockAutenticacion(usuario);
+
+        when(jwtUtil.generateToken(anyMap(), anyString())).thenReturn("token-jwt");
+        RefreshToken refreshToken = new RefreshToken();
+        refreshToken.setToken("refresh-uuid");
+        when(refreshTokenService.crear(1L)).thenReturn(refreshToken);
+        when(jwtConfig.getExpiration()).thenReturn(3600000L);
+
+        Map<String, Object> resultado = authService.login("jperez", "secreta123");
+
+        assertNotNull(resultado);
+        assertEquals("token-jwt", resultado.get("token"));
+    }
+}


### PR DESCRIPTION
…ro JWT (A8)

- SuscripcionValidator: bloquea farmacia desactivada, prueba vencida o suscripcion vencida (fechas null = sin limite)
- AuthServiceImpl.login: valida vigencia antes de emitir el token
- JwtAuthenticationFilter: rechaza con 401 tokens de farmacias vencidas
- UsuarioRepository: @EntityGraph(farmacia) en findByNombreUsuarioUsuario para evitar LazyInitializationException con open-in-view: false
- PATCH /api/v1/farmacias/{id}/suscripcion (solo superadmin): renueva vigencia, desactiva periodo de prueba y reactiva la farmacia
- Tests de login bloqueado/permitido segun estado de la farmacia