### PR TITLE
fix(compra): setear farmacia en la cabecera y en los lotes nuevos (M9b)

### DIFF
--- a/db/migration/M9b_backfill_compra_farmacia.sql
+++ b/db/migration/M9b_backfill_compra_farmacia.sql
@@ -1,0 +1,54 @@
+-- =============================================================================
+-- M9b — Backfill de farmacia_id en compras y lotes creados por compra
+-- =============================================================================
+-- Hasta este fix, CompraServiceImpl.crear() no seteaba farmacia ni en la
+-- cabecera Compra ni en los lotes nuevos que creaba: ambos quedaban con
+-- farmacia_id = NULL. Las consultas tenant-scoped por farmacia_id (listar,
+-- anular, buscar) no encuentran esas filas. El fix corrige de aquí en adelante;
+-- este script rellena las filas históricas a partir de su sucursal.
+--
+-- sucursales.farmacia_id es NOT NULL en el modelo, así que es la fuente fiable.
+--
+-- EJECUCIÓN MANUAL. No se corre automáticamente (el proyecto no usa Flyway/Liquibase).
+--
+-- ANTES DE EJECUTAR:
+--   1. Backup de las tablas `compras` e `inventario_lotes`.
+--   2. Ejecutar el SELECT de diagnóstico y revisar el conteo esperado.
+-- =============================================================================
+
+-- 1) Diagnóstico: cuántas filas tienen farmacia_id NULL y si su sucursal la resuelve.
+SELECT 'compras'         AS tabla,
+       COUNT(*)          AS con_farmacia_null,
+       SUM(CASE WHEN s.farmacia_id IS NULL THEN 1 ELSE 0 END) AS sin_sucursal_resoluble
+FROM        compras c
+LEFT JOIN   sucursales s ON s.sucursal_id = c.sucursal_id
+WHERE       c.farmacia_id IS NULL
+UNION ALL
+SELECT 'inventario_lotes',
+       COUNT(*),
+       SUM(CASE WHEN s.farmacia_id IS NULL THEN 1 ELSE 0 END)
+FROM        inventario_lotes l
+LEFT JOIN   sucursales s ON s.sucursal_id = l.sucursal_id
+WHERE       l.farmacia_id IS NULL;
+
+-- 2) Backfill. Solo toca filas con farmacia_id NULL; recupera la farmacia de la sucursal.
+START TRANSACTION;
+
+UPDATE compras c
+JOIN   sucursales s ON s.sucursal_id = c.sucursal_id
+SET    c.farmacia_id = s.farmacia_id
+WHERE  c.farmacia_id IS NULL;
+
+UPDATE inventario_lotes l
+JOIN   sucursales s ON s.sucursal_id = l.sucursal_id
+SET    l.farmacia_id = s.farmacia_id
+WHERE  l.farmacia_id IS NULL;
+
+-- Revisar las filas afectadas y, si es correcto:
+COMMIT;
+-- En caso de duda: ROLLBACK;
+
+-- RECOMENDACIÓN (cambio de esquema aparte, solo seguro DESPUÉS de este backfill):
+-- endurecer las columnas a NOT NULL para que el descuido no pueda repetirse:
+--   ALTER TABLE compras          MODIFY farmacia_id BIGINT NOT NULL;
+--   ALTER TABLE inventario_lotes MODIFY farmacia_id BIGINT NOT NULL;

--- a/src/main/java/farmacias/AppOchoa/serviceimpl/CompraServiceImpl.java
+++ b/src/main/java/farmacias/AppOchoa/serviceimpl/CompraServiceImpl.java
@@ -65,6 +65,7 @@ public class CompraServiceImpl implements CompraService {
                 .compraObservaciones(dto.getObservaciones())
                 .compraEstado(CompraEstado.activa)
                 .detalles(new ArrayList<>())
+                .farmacia(farmacia)
                 .build();
 
         BigDecimal totalAcumulado = BigDecimal.ZERO;
@@ -86,6 +87,7 @@ public class CompraServiceImpl implements CompraService {
                             .loteEstado(LoteEstado.disponible)
                             .producto(producto)
                             .sucursal(sucursal)
+                            .farmacia(farmacia)
                             .build());
 
             // Aumentar stock del lote

--- a/src/test/java/farmacias/AppOchoa/serviceImplTes/CompraServiceImplInventarioTest.java
+++ b/src/test/java/farmacias/AppOchoa/serviceImplTes/CompraServiceImplInventarioTest.java
@@ -143,6 +143,30 @@ public class CompraServiceImplInventarioTest {
     }
 
     @Test
+    @DisplayName("Comprar setea la farmacia en la cabecera y en el lote nuevo")
+    void compraSeteaFarmaciaEnCabeceraYLoteNuevo() {
+        stubCrearComun();
+        // Lote inexistente: crear() debe construir uno nuevo con farmacia seteada
+        when(loteRepository.findByLoteNumeroAndSucursal_SucursalIdAndProducto_ProductoId("L-1", SUCURSAL_ID, PRODUCTO_ID))
+                .thenReturn(Optional.empty());
+        when(inventarioRepository.findByProductoYSucursalForUpdate(PRODUCTO_ID, SUCURSAL_ID))
+                .thenReturn(Optional.empty());
+
+        ArgumentCaptor<Compra> compraCaptor = ArgumentCaptor.forClass(Compra.class);
+        ArgumentCaptor<InventarioLotes> loteCaptor = ArgumentCaptor.forClass(InventarioLotes.class);
+
+        compraService.crear(FARMACIA_ID, compraDto(8));
+
+        verify(compraRepository).save(compraCaptor.capture());
+        assertNotNull(compraCaptor.getValue().getFarmacia(), "la cabecera Compra debe llevar farmacia");
+        assertEquals(FARMACIA_ID, compraCaptor.getValue().getFarmacia().getFarmaciaId());
+
+        verify(loteRepository).save(loteCaptor.capture());
+        assertNotNull(loteCaptor.getValue().getFarmacia(), "el lote nuevo debe llevar farmacia");
+        assertEquals(FARMACIA_ID, loteCaptor.getValue().getFarmacia().getFarmaciaId());
+    }
+
+    @Test
     @DisplayName("Anular una compra activa decrementa el inventario agregado")
     void anularCompraDecrementaInventario() {
         CompraDetalle detalle = CompraDetalle.builder()


### PR DESCRIPTION
CompraServiceImpl.crear() no incluia farmacia ni en el builder de la Compra ni en el del lote nuevo (orElseGet), asi que ambos se guardaban con farmacia_id NULL y las consultas tenant-scoped por farmacia_id no los encontraban (compras no listables/anulables por su propia farmacia). Venta ya seteaba la farmacia; esto alinea Compra.

Cierra ademas el borde donde la anulacion M9 tomaba lote.getFarmacia() de un lote creado con farmacia null y lo pasaba a ajustarInventarioAgregado.

Incluye db/migration/M9b_backfill_compra_farmacia.sql para rellenar las filas historicas con farmacia_id NULL desde su sucursal (ejecucion manual).