### PR TITLE
feat(farmacia): crear administrador inicial en el alta de farmacia

### DIFF
--- a/src/main/java/farmacias/AppOchoa/dto/farmacia/FarmaciaCreateDTO.java
+++ b/src/main/java/farmacias/AppOchoa/dto/farmacia/FarmaciaCreateDTO.java
@@ -1,6 +1,8 @@
 package farmacias.AppOchoa.dto.farmacia;
 
 import farmacias.AppOchoa.model.PlanTipo;
+import farmacias.AppOchoa.dto.usuario.UsuarioCreateDTO;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -33,4 +35,8 @@ public class FarmaciaCreateDTO {
 
     private LocalDate pruebaHasta;
     private LocalDate suscripcionVigencia;
+
+    @NotNull(message = "El administrador inicial es obligatorio")
+    @Valid
+    private UsuarioCreateDTO adminInicial;
 }

--- a/src/main/java/farmacias/AppOchoa/serviceimpl/FarmaciaServiceImpl.java
+++ b/src/main/java/farmacias/AppOchoa/serviceimpl/FarmaciaServiceImpl.java
@@ -10,6 +10,7 @@ import farmacias.AppOchoa.model.Farmacia;
 import farmacias.AppOchoa.model.PlanTipo;
 import farmacias.AppOchoa.repository.FarmaciaRepository;
 import farmacias.AppOchoa.services.FarmaciaService;
+import farmacias.AppOchoa.services.UsuarioService;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -19,9 +20,12 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 public class FarmaciaServiceImpl implements FarmaciaService {
     private final FarmaciaRepository farmaciaRepository;
+    private final UsuarioService usuarioService;
 
-    public FarmaciaServiceImpl(FarmaciaRepository farmaciaRepository1){
+    public FarmaciaServiceImpl(FarmaciaRepository farmaciaRepository1,
+                               UsuarioService usuarioService){
         this.farmaciaRepository = farmaciaRepository1;
+        this.usuarioService = usuarioService;
     }
 
     @Override
@@ -44,7 +48,9 @@ public class FarmaciaServiceImpl implements FarmaciaService {
                 .build();
 
 
-        return FarmaciaResponseDTO.fromEntity(farmaciaRepository.save(farmacia));
+        Farmacia farmaciaGuardada = farmaciaRepository.save(farmacia);
+        usuarioService.crearAdminInicial(dto.getAdminInicial(), farmaciaGuardada);
+        return FarmaciaResponseDTO.fromEntity(farmaciaGuardada);
     }
     private int resolverMaxSucursales(PlanTipo plan) {
         return switch (plan) {

--- a/src/main/java/farmacias/AppOchoa/serviceimpl/UsuarioServiceImpl.java
+++ b/src/main/java/farmacias/AppOchoa/serviceimpl/UsuarioServiceImpl.java
@@ -84,6 +84,28 @@ public class UsuarioServiceImpl implements UsuarioService, UserDetailsService {
     }
 
     @Override
+    public UsuarioResponseDTO crearAdminInicial(UsuarioCreateDTO dto, Farmacia farmacia) {
+        if (usuarioRepository.existsByNombreUsuarioUsuario(dto.getNombreUsuario())) {
+            throw new DuplicateResourceException("El nombre de usuario '" + dto.getNombreUsuario() + "' ya está en uso");
+        }
+        // El rol lo dicta el servidor: este endpoint SIEMPRE crea al administrador
+        // inicial. Ignora dto.getRol() para no permitir crear un encargado sin sucursal
+        // o un superadmin colgado de una farmacia por la puerta lateral.
+        // La sucursal nace null: en el modelo 1:1 la crea el propio admin tras entrar.
+        Usuario usuario = Usuario.builder()
+                .nombreUsuarioUsuario(dto.getNombreUsuario())
+                .usuarioContrasenaHash(passwordEncoder.encode(dto.getContrasena()))
+                .usuarioNombre(dto.getNombre())
+                .usuarioApellido(dto.getApellido())
+                .usuarioRol(UsuarioRol.administrador)
+                .sucursal(null)
+                .farmacia(farmacia)
+                .usuarioEstado(true)
+                .build();
+        return UsuarioResponseDTO.fromEntity(usuarioRepository.save(usuario));
+    }
+
+    @Override
     @Transactional(readOnly = true)
     public UsuarioResponseDTO obtenerPorId(Long farmaciaId, Long id) {
         return usuarioRepository.findByUsuarioIdAndFarmacia_FarmaciaId(id, farmaciaId)

--- a/src/main/java/farmacias/AppOchoa/services/UsuarioService.java
+++ b/src/main/java/farmacias/AppOchoa/services/UsuarioService.java
@@ -5,12 +5,14 @@ import farmacias.AppOchoa.dto.usuario.UsuarioCreateDTO;
 import farmacias.AppOchoa.dto.usuario.UsuarioUpdateDTO;
 import farmacias.AppOchoa.dto.usuario.UsuarioResponseDTO;
 import farmacias.AppOchoa.dto.usuario.UsuarioSimpleDTO;
+import farmacias.AppOchoa.model.Farmacia;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface UsuarioService {
 
     UsuarioResponseDTO crearUsuario(Long farmaciaId, UsuarioCreateDTO dto);
+    UsuarioResponseDTO crearAdminInicial(UsuarioCreateDTO dto, Farmacia farmacia);
     UsuarioResponseDTO obtenerPorId(Long farmaciaId, Long id);
     Page<UsuarioSimpleDTO> listarUsuariosActivosPaginado(Long farmaciaId, Pageable pageable);
     Page<UsuarioSimpleDTO> buscarPorTexto(Long farmaciaId, String texto, Pageable pageable);

--- a/src/test/java/farmacias/AppOchoa/serviceImplTes/FarmaciaServiceImplTest.java
+++ b/src/test/java/farmacias/AppOchoa/serviceImplTes/FarmaciaServiceImplTest.java
@@ -4,10 +4,14 @@ package farmacias.AppOchoa.serviceImplTes;
 import farmacias.AppOchoa.dto.farmacia.FarmaciaCreateDTO;
 import farmacias.AppOchoa.dto.farmacia.FarmaciaResponseDTO;
 import farmacias.AppOchoa.dto.farmacia.FarmaciaSimpleDTO;
+import farmacias.AppOchoa.dto.usuario.UsuarioCreateDTO;
+import farmacias.AppOchoa.dto.usuario.UsuarioResponseDTO;
 import farmacias.AppOchoa.model.Farmacia;
 import farmacias.AppOchoa.model.PlanTipo;
+import farmacias.AppOchoa.model.UsuarioRol;
 import farmacias.AppOchoa.repository.FarmaciaRepository;
 import farmacias.AppOchoa.serviceimpl.FarmaciaServiceImpl;
+import farmacias.AppOchoa.services.UsuarioService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -34,6 +38,8 @@ public class FarmaciaServiceImplTest {
 
     @Mock
     private FarmaciaRepository farmaciaRepository;
+    @Mock
+    private UsuarioService usuarioService;
     @InjectMocks
     private FarmaciaServiceImpl farmaciaService;
 
@@ -49,6 +55,14 @@ public class FarmaciaServiceImplTest {
         dto.setPlanTipo(PlanTipo.basico);
         dto.setSuscripcionVigencia(LocalDate.of(2026, 3, 25));
 
+        UsuarioCreateDTO adminInicial = new UsuarioCreateDTO();
+        adminInicial.setNombreUsuario("adminochoa");
+        adminInicial.setContrasena("Password123");
+        adminInicial.setNombre("Admin");
+        adminInicial.setApellido("Ochoa");
+        adminInicial.setRol(UsuarioRol.administrador);
+        dto.setAdminInicial(adminInicial);
+
         Farmacia farmacia = new Farmacia();
         farmacia.setFarmaciaId(1L);
         farmacia.setFarmaciaNombre("Ochoa");
@@ -59,6 +73,7 @@ public class FarmaciaServiceImplTest {
         farmacia.setSuscripcionVigencia(LocalDate.of(2026, 3, 25));
 
         when(farmaciaRepository.save(any(Farmacia.class))).thenReturn(farmacia);
+        when(usuarioService.crearAdminInicial(any(), any())).thenReturn(new UsuarioResponseDTO());
 
         FarmaciaResponseDTO resultado  = farmaciaService.crear(dto);
         assertNotNull(resultado);


### PR DESCRIPTION
El alta de farmacia (POST /farmacias) vuelve a crear el usuario administrador inicial en la misma transacción, restaurando el contrato que el frontend en producción ya consume (modal "Nueva farmacia").

- FarmaciaCreateDTO: restaura el campo adminInicial (@NotNull @Valid).
- UsuarioService.crearAdminInicial(dto, farmacia): rol hardcodeado a 'administrador' server-side (ignora dto.getRol() para evitar crear un encargado sin sucursal o un superadmin por la puerta lateral); sucursal null (en el modelo 1:1 la crea el admin después de entrar); valida nombreUsuario duplicado; sin validación de cupo (primer usuario).
- Atómico: @Transactional a nivel de clase + rollback en RuntimeException.
- No se crea sucursal Principal; el NIT sigue en Sucursal, no en Farmacia.