### PR TITLE
feat(fel): add credit note and cancellation certification via TEKRA

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,34 @@
+# === PLANTILLA de variables de entorno (SIN secretos reales) ===
+# Copiar a .env.local (tu maquina), .env.qa o .env.prod segun el entorno
+# y rellenar con los valores reales. Los .env reales estan en .gitignore.
+#
+# Cada entorno debe apuntar a SU PROPIA base de datos:
+#   - local -> MySQL en tu PC (localhost:3306)
+#   - qa    -> cluster/servidor de QA (nunca la DB de prod)
+#   - prod  -> cluster DigitalOcean de produccion
+
+# Perfil de Spring a activar: dev | qa | prod
+SPRING_PROFILES_ACTIVE=dev
+
+# --- Base de datos ---
+DATABASE_URL=jdbc:mysql://localhost:3306/NOMBRE_DB
+DATABASE_USERNAME=usuario
+DATABASE_PASSWORD=clave
+
+# --- JWT ---
+JWT_SECRET=genera-un-secreto-largo-por-entorno
+JWT_EXPIRATION=900000
+REFRESH_TOKEN_EXPIRATION=604800000
+
+# --- FEL / TEKRA (facturacion) ---
+FEL_ENCRYPTION_KEY=genera-una-clave-base64-por-entorno
+TEKRA_IP_ORIGEN=0.0.0.0
+
+# --- Superadmin bootstrap ---
+SUPERADMIN_USER=admin
+SUPERADMIN_PASS=cambia-esta-clave
+
+# --- Observabilidad (opcional en local) ---
+LOKI_URL=
+LOKI_USERNAME=
+LOKI_PASSWORD=

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,10 @@ build/
 .idea/
 out/
 .env
+.env.local
+.env.qa
+.env.prod
+!.env.example
 *.zip
 *.jar
 backup_*.sql

--- a/src/main/java/farmacias/AppOchoa/controller/VentaFelController.java
+++ b/src/main/java/farmacias/AppOchoa/controller/VentaFelController.java
@@ -1,5 +1,6 @@
 package farmacias.AppOchoa.controller;
 
+import farmacias.AppOchoa.dto.ventafel.AnulacionRequestDTO;
 import farmacias.AppOchoa.dto.ventafel.VentaFelCreateDTO;
 import farmacias.AppOchoa.dto.ventafel.VentaFelResponseDTO;
 import farmacias.AppOchoa.dto.ventafel.VentaFelSimpleDTO;
@@ -58,5 +59,13 @@ public class VentaFelController extends  BaseController{
     @PostMapping("/{id}/certificar")
     public ResponseEntity<VentaFelResponseDTO> certificar(@PathVariable Long id) {
         return ResponseEntity.ok(ventaFelService.certificar(getFarmaciaId(), id));
+    }
+
+    @PostMapping("/{id}/anular")
+    public ResponseEntity<VentaFelResponseDTO> anular(
+            @PathVariable Long id,
+            @RequestBody @Valid AnulacionRequestDTO dto){
+        return ResponseEntity.ok(ventaFelService.anular(getFarmaciaId(), id, dto.motivo()));
+
     }
 }

--- a/src/main/java/farmacias/AppOchoa/controller/VentaFelNotasCreditoController.java
+++ b/src/main/java/farmacias/AppOchoa/controller/VentaFelNotasCreditoController.java
@@ -52,4 +52,9 @@ public class VentaFelNotasCreditoController extends  BaseController {
         ventaFelNotasCreditoService.eliminar(getFarmaciaId(), id);
         return ResponseEntity.noContent().build();
     }
+
+    @PostMapping("/{id}/certificar")
+    public ResponseEntity<VentaFelNotasCreditoResponseDTO> notaCredito(@PathVariable Long id){
+        return ResponseEntity.ok(ventaFelNotasCreditoService.notaCredito(getFarmaciaId(), id));
+    }
 }

--- a/src/main/java/farmacias/AppOchoa/dto/ventafel/AnulacionRequestDTO.java
+++ b/src/main/java/farmacias/AppOchoa/dto/ventafel/AnulacionRequestDTO.java
@@ -1,0 +1,8 @@
+package farmacias.AppOchoa.dto.ventafel;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record AnulacionRequestDTO(@NotBlank String motivo) {
+
+
+}

--- a/src/main/java/farmacias/AppOchoa/dto/ventafel/VentaFelResponseDTO.java
+++ b/src/main/java/farmacias/AppOchoa/dto/ventafel/VentaFelResponseDTO.java
@@ -20,6 +20,7 @@ public class VentaFelResponseDTO {
     private LocalDateTime felFechaCertificacion;
     private String felErrorDescripcion;
     private Integer felIntentos;
+    private String felSerie;
     private LocalDateTime auditoriaFechaCreacion;
 
     public static VentaFelResponseDTO fromEntity(VentaFel ventaFel) {
@@ -28,6 +29,8 @@ public class VentaFelResponseDTO {
                 .ventaId(ventaFel.getVenta() != null ? ventaFel.getVenta().getVentaId() : null)
                 .felEstado(ventaFel.getFelEstado())
                 .felUuid(ventaFel.getFelUuid())
+                .felSerie(ventaFel.getFelSerie())
+                .felNumeroAutorizacion(ventaFel.getFelNumeroAutorizacion())
                 .felNumeroAutorizacion(ventaFel.getFelNumeroAutorizacion())
                 .felFechaCertificacion(ventaFel.getFelFechaCertificacion())
                 .felErrorDescripcion(ventaFel.getFelErrorDescripcion())

--- a/src/main/java/farmacias/AppOchoa/dto/ventafel/VentaFelSimpleDTO.java
+++ b/src/main/java/farmacias/AppOchoa/dto/ventafel/VentaFelSimpleDTO.java
@@ -13,6 +13,8 @@ public class VentaFelSimpleDTO {
     private Long felId;
     private VentaFelEstado felEstado;
     private String felUuid;
+    private String felSerie;
+    private String felNumeroAutorizacion;
 
     public static VentaFelSimpleDTO fromEntity(VentaFel ventaFel) {
         return VentaFelSimpleDTO.builder()

--- a/src/main/java/farmacias/AppOchoa/integracionfel/DteXmlAnulacionBuilder.java
+++ b/src/main/java/farmacias/AppOchoa/integracionfel/DteXmlAnulacionBuilder.java
@@ -1,0 +1,41 @@
+package farmacias.AppOchoa.integracionfel;
+
+import farmacias.AppOchoa.model.Venta;
+import farmacias.AppOchoa.model.VentaFel;
+import org.springframework.stereotype.Component;
+
+import java.security.SecureRandom;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+@Component
+public class DteXmlAnulacionBuilder {
+
+    private static final DateTimeFormatter FECHA_FORMATTER =
+            DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSSSSS");
+
+    private static final DateTimeFormatter FECHA_ORIGEN_FORMATTER =
+            DateTimeFormatter.ofPattern("yyyy-MM-dd");
+
+    public String construir(VentaFel ventaFel, String motivo){
+        Venta venta = ventaFel.getVenta();
+
+        String uuidAnular = ventaFel.getFelUuid();
+        String nitEmisor = ventaFel.getSucursal().getSucursalNit();
+        String idReceptor = venta.getVentaNitCliente();
+        String fechaEmision = venta.getVentaFecha().format(FECHA_FORMATTER) + "-06:00";
+        String fechaAnulacion = LocalDateTime.now().format(FECHA_FORMATTER) + "-06:00";
+
+        return """
+        <?xml version="1.0"?>
+        <dte:GTAnulacionDocumento Version="0.1" xmlns:dte="http://www.sat.gob.gt/dte/fel/0.1.0" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            <dte:SAT>
+                <dte:AnulacionDTE ID="DatosCertificados">
+                    <dte:DatosGenerales ID="DatosAnulacion" NumeroDocumentoAAnular="%s" NITEmisor="%s" IDReceptor="%s" FechaEmisionDocumentoAnular="%s" FechaHoraAnulacion="%s" MotivoAnulacion="%s" />
+                </dte:AnulacionDTE>
+            </dte:SAT>
+        </dte:GTAnulacionDocumento>
+        """.formatted(uuidAnular, nitEmisor, idReceptor, fechaEmision, fechaAnulacion, motivo);
+    }
+
+}

--- a/src/main/java/farmacias/AppOchoa/integracionfel/DteXmlNotaCreditoBuilder.java
+++ b/src/main/java/farmacias/AppOchoa/integracionfel/DteXmlNotaCreditoBuilder.java
@@ -3,39 +3,53 @@ package farmacias.AppOchoa.integracionfel;
 import farmacias.AppOchoa.model.Producto;
 import farmacias.AppOchoa.model.Venta;
 import farmacias.AppOchoa.model.VentaDetalle;
+import farmacias.AppOchoa.model.VentaFel;
 import org.springframework.stereotype.Component;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
-import java.security.SecureRandom;
+import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 
 @Component
-public class DteXmlBuilder {
+public class DteXmlNotaCreditoBuilder {
 
     private static final DateTimeFormatter FECHA_FORMATTER =
             DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSSSSS");
 
-    public String construir(Venta venta) {
-        String fechaEmision = venta.getVentaFecha().format(FECHA_FORMATTER) + "-06:00";
-        int numeroAcceso = new SecureRandom().nextInt(900_000_000) + 100_000_000;
+    // El complemento ReferenciasNota pide solo la fecha, sin hora.
+    private static final DateTimeFormatter FECHA_ORIGEN_FORMATTER =
+            DateTimeFormatter.ofPattern("yyyy-MM-dd");
 
-        String nitEmisor = venta.getSucursal().getSucursalNit();
-        String nombreEmisor = venta.getSucursal().getSucursalNombre();
-        String codigoEstablecimiento = venta.getSucursal().getCodigoEstablecimiento();
-        String afiliacionIva = venta.getSucursal().getAfiliacionIva();
-        String municipio = venta.getSucursal().getMunicipio();
-        String departamento = venta.getSucursal().getDepartamento();
-        String codigoPostal = venta.getSucursal().getCodigoPostal();
-        String sucursalDireccion = venta.getSucursal().getSucursalDireccion();
+    public String construir(VentaFel ventaFel){
+        String fechaHoraEmision = LocalDateTime.now().format(FECHA_FORMATTER) + "-06:00";
+        Venta venta = ventaFel.getVenta();
+
+        String nitEmisor = ventaFel.getSucursal().getSucursalNit();
+        String nombreEmisor = ventaFel.getSucursal().getSucursalNombre();
+        String codigoEstablecimiento = ventaFel.getSucursal().getCodigoEstablecimiento();
+        String afiliacionIva = ventaFel.getSucursal().getAfiliacionIva();
+        String municipio = ventaFel.getSucursal().getMunicipio();
+        String departamento = ventaFel.getSucursal().getDepartamento();
+        String codigoPostal = ventaFel.getSucursal().getCodigoPostal();
+        String sucursalDireccion = ventaFel.getSucursal().getSucursalDireccion();
+        String serieOrigen = ventaFel.getFelSerie();
+        String numeroOrigen = ventaFel.getFelNumeroDocumento();
 
         String idReceptor = venta.getVentaNitCliente();
         String nombreReceptor = venta.getVentaNombreCliente();
+
+        // Datos del documento original al que esta nota hace referencia.
+        String uuidOrigen = ventaFel.getFelUuid();
+        String fechaEmisionOrigen = venta.getVentaFecha().format(FECHA_ORIGEN_FORMATTER);
+
+
+
         StringBuilder items = new StringBuilder();
         BigDecimal totalImpuesto = BigDecimal.ZERO;
         int numeroLinea = 1;
 
-        for (VentaDetalle detalle : venta.getDetalles()) {
+        for(VentaDetalle detalle : venta.getDetalles()){
             Producto producto = detalle.getProducto();
             BigDecimal precio = detalle.getDetalleSubtotal();
             BigDecimal tasaIva = producto.getProductoIva();
@@ -65,6 +79,7 @@ public class DteXmlBuilder {
                     """.formatted(numeroLinea, detalle.getDetalleCantidad(), producto.getProductoNombre(),
                     detalle.getDetallePrecioUnitario(), precio, montoGravable, montoImpuesto, precio));
             numeroLinea++;
+
         }
 
         return """
@@ -79,7 +94,7 @@ public class DteXmlBuilder {
                     <dte:SAT ClaseDocumento="dte">
                         <dte:DTE ID="DatosCertificados">
                             <dte:DatosEmision ID="DatosEmision">
-                                <dte:DatosGenerales Tipo="FACT" FechaHoraEmision="%s" CodigoMoneda="GTQ" NumeroAcceso="%d" />
+                                <dte:DatosGenerales Tipo="NCRE" FechaHoraEmision="%s" CodigoMoneda="GTQ" />
                                 <dte:Emisor NITEmisor="%s" NombreEmisor="%s" CodigoEstablecimiento="%s" NombreComercial="%s" CorreoEmisor="" AfiliacionIVA="%s">
                                     <dte:DireccionEmisor>
                                         <dte:Direccion>%s</dte:Direccion>
@@ -98,8 +113,6 @@ public class DteXmlBuilder {
                                         <dte:Pais>GT</dte:Pais>
                                     </dte:DireccionReceptor>
                                 </dte:Receptor>
-                                <!-- TipoFrase=1 / CodigoEscenario=1: confirmado por TEKRA para su propio NIT/régimen GEN,
-                                     válido mientras factures bajo el NIT autorizado de TEKRA. -->
                                 <dte:Frases>
                                     <dte:Frase TipoFrase="1" CodigoEscenario="1" />
                                 </dte:Frases>
@@ -112,6 +125,11 @@ public class DteXmlBuilder {
                                     </dte:TotalImpuestos>
                                     <dte:GranTotal>%s</dte:GranTotal>
                                 </dte:Totales>
+                                <dte:Complementos>
+                                    <dte:Complemento IDComplemento="" NombreComplemento="ReferenciasNota" URIComplemento="">
+                                        <cno:ReferenciasNota Version="1" NumeroAutorizacionDocumentoOrigen="%s" FechaEmisionDocumentoOrigen="%s" SerieDocumentoOrigen="%s" NumeroDocumentoOrigen="%s" />
+                                    </dte:Complemento>
+                                </dte:Complementos>
                             </dte:DatosEmision>
                         </dte:DTE>
                         <dte:Adenda>
@@ -120,8 +138,7 @@ public class DteXmlBuilder {
                     </dte:SAT>
                 </dte:GTDocumento>
                 """.formatted(
-                fechaEmision,
-                numeroAcceso,
+                fechaHoraEmision,
                 nitEmisor,
                 nombreEmisor,
                 codigoEstablecimiento,
@@ -136,6 +153,10 @@ public class DteXmlBuilder {
                 items.toString(),
                 totalImpuesto,
                 venta.getVentaTotal(),
+                uuidOrigen,
+                fechaEmisionOrigen,
+                serieOrigen,
+                numeroOrigen,
                 System.currentTimeMillis()
         );
     }

--- a/src/main/java/farmacias/AppOchoa/integracionfel/TekraCertificacionResultado.java
+++ b/src/main/java/farmacias/AppOchoa/integracionfel/TekraCertificacionResultado.java
@@ -32,6 +32,9 @@ public class TekraCertificacionResultado {
     public static  TekraCertificacionResultado error(int codigoError, String mensajeError){
         return new TekraCertificacionResultado(false, codigoError, mensajeError,  null, null, null, null, null);
     }
+    public static TekraCertificacionResultado exitoAnulacion(){
+        return new TekraCertificacionResultado(true, 0, null, null, null, null, null, null);
+    }
 
     public boolean isExitoso() {return exitoso;}
     public int getCodigoError() {return codigoError;}

--- a/src/main/java/farmacias/AppOchoa/integracionfel/TekraClient.java
+++ b/src/main/java/farmacias/AppOchoa/integracionfel/TekraClient.java
@@ -7,6 +7,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
 
+import java.nio.charset.StandardCharsets;
+
 @Component
 public class TekraClient {
 
@@ -19,7 +21,9 @@ public class TekraClient {
 
     public String certificar(String soapEnvelope) {
         HttpHeaders headers = new HttpHeaders();
-        headers.setContentType(MediaType.TEXT_XML);
+        headers.set("SOAPAction",
+                "\"http://apicertificacion.desa.tekra.com.gt:8080/certificacion/wsdl/CertificacionDocumento\"");
+        headers.setContentType(new MediaType("text", "xml", StandardCharsets.UTF_8));
 
         HttpEntity<String> request = new HttpEntity<>(soapEnvelope, headers);
 
@@ -27,6 +31,16 @@ public class TekraClient {
                 URL_CERTIFICACION_PRUEBAS, request, String.class
         );
 
+        return response.getBody();
+    }
+
+
+    public String anular(String soapEnvelope) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("SOAPAction", "\"http://apicertificacion.desa.tekra.com.gt:8080/certificacion/wsdl/AnulacionDocumento\"");
+        headers.setContentType(new MediaType("text", "xml", StandardCharsets.UTF_8));
+        HttpEntity<String> request = new HttpEntity<>(soapEnvelope, headers);
+        ResponseEntity<String> response = restTemplate.postForEntity(URL_CERTIFICACION_PRUEBAS, request, String.class);
         return response.getBody();
     }
 }

--- a/src/main/java/farmacias/AppOchoa/integracionfel/TekraResponseParser.java
+++ b/src/main/java/farmacias/AppOchoa/integracionfel/TekraResponseParser.java
@@ -36,14 +36,11 @@ public class TekraResponseParser {
             // DocumentoCertificado. El manual también menciona campos "NumeroAutorizacion"/
             // "SerieDocumento" sueltos a nivel superior, pero no aparecen así en el
             // ejemplo real que tenemos — falta confirmar contra una respuesta real de TEKRA.
-            Element numeroAutorizacionEl = (Element) doc.getElementsByTagName("dte:NumeroAutorizacion").item(0);
-            String uuid = numeroAutorizacionEl.getTextContent();
-            String serie = numeroAutorizacionEl.getAttribute("Serie");
-            String numero = numeroAutorizacionEl.getAttribute("Numero");
-
-            String fechaCertificacion = textoDeEtiqueta(doc, "dte:FechaHoraCertificacion");
-
-            String xmlCertificado = extraerEntre(respuestaSoap, "<DocumentoCertificado>", "</DocumentoCertificado>");
+            String uuid = textoDeEtiqueta(doc, "NumeroAutorizacion");
+            String serie = textoDeEtiqueta(doc, "SerieDocumento");
+            String numero = textoDeEtiqueta(doc, "NumeroDocumento");
+            String fechaCertificacion = textoDeEtiqueta(doc, "FechaHoraCertificacion");
+            String xmlCertificado = textoDeEtiqueta(doc, "DocumentoCertificado");
 
             return TekraCertificacionResultado.exito(uuid, serie, numero, fechaCertificacion, xmlCertificado);
 
@@ -73,5 +70,27 @@ public class TekraResponseParser {
             return null;
         }
         return texto.substring(desde + inicio.length(), hasta);
+    }
+
+    public TekraCertificacionResultado parsearAnulacion(String respuestaSoap) {
+        try {
+            Document doc = parseXml(respuestaSoap);
+
+            String resultadoJson = textoDeEtiqueta(doc, "ResultadoAnulacion");
+            JsonNode resultado = objectMapper.readTree(resultadoJson);
+            int codigoError = resultado.get("error").asInt();
+
+            if (codigoError != 0) {
+                String detalle = resultado.has("frases") && !resultado.get("frases").isNull()
+                        ? resultado.get("frases").toString()
+                        : resultadoJson;
+                return TekraCertificacionResultado.error(codigoError, detalle);
+            }
+
+            return TekraCertificacionResultado.exitoAnulacion();
+
+        } catch (Exception e) {
+            throw new RuntimeException("Error al parsear la respuesta de anulación de TEKRA", e);
+        }
     }
 }

--- a/src/main/java/farmacias/AppOchoa/integracionfel/TekraSoapBuilder.java
+++ b/src/main/java/farmacias/AppOchoa/integracionfel/TekraSoapBuilder.java
@@ -6,7 +6,7 @@ import org.springframework.stereotype.Component;
 
 @Component
 public class TekraSoapBuilder {
-    private static final String ID_ORIGEN = "Sistema Facturación";
+    private static final String ID_ORIGEN = "Sistema Facturacion";
     private final String ipOrigen;
 
     public TekraSoapBuilder(@Value("${fel.tekra.ip-origen}") String ipOrigen) {
@@ -19,6 +19,7 @@ public class TekraSoapBuilder {
         String validarIdentificador = credenciales.getValidarIdentificador() ? "SI" : "NO";
 
         return """
+                <?xml version="1.0" encoding="UTF-8"?>
                 <Envelope xmlns="http://schemas.xmlsoap.org/soap/envelope/">
                     <Body>
                         <CertificacionDocumento xmlns="http://apicertificacion.desa.tekra.com.gt:8080/certificacion/wsdl/">
@@ -49,5 +50,34 @@ public class TekraSoapBuilder {
                 validarIdentificador,
                 dteXml
         );
+    }
+
+    public String construirSobreAnulacion(CredencialesFel credenciales, String usuarioPlano, String clavePlano, String dteXml) {
+        String firmarEmisor = credenciales.getFirmarEmisor() ? "SI" : "NO";
+
+        return """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <Envelope xmlns="http://schemas.xmlsoap.org/soap/envelope/">
+                <Body>
+                    <AnulacionDocumento xmlns="http://apicertificacion.desa.tekra.com.gt:8080/certificacion/wsdl/">
+                        <Autenticacion>
+                            <pn_usuario>%s</pn_usuario>
+                            <pn_clave>%s</pn_clave>
+                            <pn_cliente>%d</pn_cliente>
+                            <pn_contrato>%d</pn_contrato>
+                            <pn_id_origen>%s</pn_id_origen>
+                            <pn_ip_origen>%s</pn_ip_origen>
+                            <pn_firmar_emisor>%s</pn_firmar_emisor>
+                        </Autenticacion>
+                        <Documento>
+                            <![CDATA[%s]]>
+                        </Documento>
+                    </AnulacionDocumento>
+                </Body>
+            </Envelope>
+            """.formatted(
+                usuarioPlano, clavePlano,
+                credenciales.getCredencialCliente(), credenciales.getCredencialContrato(),
+                ID_ORIGEN, ipOrigen, firmarEmisor, dteXml);
     }
 }

--- a/src/main/java/farmacias/AppOchoa/model/InventarioLotes.java
+++ b/src/main/java/farmacias/AppOchoa/model/InventarioLotes.java
@@ -53,12 +53,6 @@ public class InventarioLotes {
     @JoinColumn(name = "farmacia_id", nullable = false)
     private Farmacia farmacia;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumns({
-            @JoinColumn(name = "producto_id", referencedColumnName = "producto_id", insertable = false, updatable = false),
-            @JoinColumn(name = "sucursal_id", referencedColumnName = "sucursal_id", insertable = false, updatable = false)
-    })
-    private Inventario inventario;
 
 
 }

--- a/src/main/java/farmacias/AppOchoa/model/VentaFel.java
+++ b/src/main/java/farmacias/AppOchoa/model/VentaFel.java
@@ -31,6 +31,16 @@ public class VentaFel {
     @Column(name = "fel_uuid", length = 36)
     private String felUuid;
 
+    //agregados en el refactory
+    @Column(name = "fel_serie", length = 50)
+    private String felSerie;
+
+    @Column(name = "fel_numero_documento", length =  50)
+    private String felNumeroDocumento;
+
+    @Column(name = "fel_fecha_emision")
+    private LocalDateTime felFechaEmision;
+
     @Column(name = "fel_numero_autorizacion", length = 50)
     private String felNumeroAutorizacion;
 

--- a/src/main/java/farmacias/AppOchoa/model/VentaFelNotasCredito.java
+++ b/src/main/java/farmacias/AppOchoa/model/VentaFelNotasCredito.java
@@ -21,7 +21,7 @@ public class VentaFelNotasCredito {
     @Column(name = "nota_uuid", length = 36)
     private String notaUuid;
 
-    @Column(name = "nota_numero_autorizacion", nullable = false, length = 50)
+    @Column(name = "nota_numero_autorizacion")
     private String notaNumeroAutorizacion;
 
     @Column(name = "nota_motivo", columnDefinition = "TEXT", nullable = false)

--- a/src/main/java/farmacias/AppOchoa/repository/InventarioRepository.java
+++ b/src/main/java/farmacias/AppOchoa/repository/InventarioRepository.java
@@ -1,6 +1,8 @@
 package farmacias.AppOchoa.repository;
 
 import farmacias.AppOchoa.model.Inventario;
+import farmacias.AppOchoa.model.Producto;
+import farmacias.AppOchoa.model.Sucursal;
 import jakarta.persistence.LockModeType;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -61,4 +63,5 @@ public interface InventarioRepository extends JpaRepository<Inventario, Long> {
             "LOWER(i.producto.productoNombre) LIKE LOWER(CONCAT('%', :texto, '%')) OR " +
             "LOWER(i.sucursal.sucursalNombre) LIKE LOWER(CONCAT('%', :texto, '%')))")
     Page<Inventario> buscarPorTexto(@Param("sucursalId") Long sucursalId, @Param("texto") String texto, Pageable pageable);
+    Optional<Inventario> findByProductoAndSucursal(Producto producto, Sucursal sucursal);
 }

--- a/src/main/java/farmacias/AppOchoa/repository/VentaFelNotasCreditoRepository.java
+++ b/src/main/java/farmacias/AppOchoa/repository/VentaFelNotasCreditoRepository.java
@@ -48,4 +48,7 @@ public interface VentaFelNotasCreditoRepository extends JpaRepository<VentaFelNo
     Page<VentaFelNotasCredito> findBySucursal_SucursalIdAndNotaEstadoAndAuditoriaFechaCreacionBetween(Long sucursalId, NotaEstado notaEstado, LocalDateTime inicio, LocalDateTime fin, Pageable pageable);
     Page<VentaFelNotasCredito> findBySucursal_SucursalIdAndNotaEstado(Long sucursalId, NotaEstado notaEstado, Pageable pageable);
     Page<VentaFelNotasCredito> findBySucursal_SucursalIdAndAuditoriaFechaCreacionBetween(Long sucursalId, LocalDateTime inicio, LocalDateTime fin, Pageable pageable);
+    boolean existsByVentaFel_FelIdAndNotaEstado(Long felId, NotaEstado notaEstado);
+
+
 }

--- a/src/main/java/farmacias/AppOchoa/repository/VentaFelRepository.java
+++ b/src/main/java/farmacias/AppOchoa/repository/VentaFelRepository.java
@@ -1,5 +1,6 @@
 package farmacias.AppOchoa.repository;
 
+import farmacias.AppOchoa.model.NotaEstado;
 import farmacias.AppOchoa.model.VentaFel;
 import farmacias.AppOchoa.model.VentaFelEstado;
 import org.springframework.data.domain.Page;
@@ -28,5 +29,4 @@ public interface VentaFelRepository extends JpaRepository<VentaFel, Long> {
 
     Page<VentaFel> findBySucursal_SucursalId(Long sucursalId, Pageable pageable);
     java.util.Optional<VentaFel> findByFelIdAndSucursal_SucursalId(Long felId, Long sucursalId);
-
 }

--- a/src/main/java/farmacias/AppOchoa/serviceimpl/CompraServiceImpl.java
+++ b/src/main/java/farmacias/AppOchoa/serviceimpl/CompraServiceImpl.java
@@ -100,6 +100,12 @@ public class CompraServiceImpl implements CompraService {
                     producto.getProductoId(),
                     pid -> obtenerInventarioConLock(farmacia, producto, sucursal));
 
+            // //Guarda el inventario de ese producto si todavia no existe
+            if(inventario.getInventarioId() == null){
+                inventario = inventarioRepository.saveAndFlush(inventario);
+                inventarioPorProducto.put(producto.getProductoId(), inventario);
+            }
+
             int stockAnterior = inventario.getInventarioCantidadActual();
             int stockPosterior = stockAnterior + detDto.getCantidad();
             inventario.setInventarioCantidadActual(stockPosterior);
@@ -131,6 +137,8 @@ public class CompraServiceImpl implements CompraService {
             CompraDetalle detalle = CompraDetalle.builder()
                     .compra(compra)
                     .producto(producto)
+                    .farmacia(farmacia)
+                    .sucursal(sucursal)
                     .loteId(lote)
                     .detalleCantidad(detDto.getCantidad())
                     .detallePrecioUnitario(detDto.getPrecioUnitario())

--- a/src/main/java/farmacias/AppOchoa/serviceimpl/ExcelServiceImpl.java
+++ b/src/main/java/farmacias/AppOchoa/serviceimpl/ExcelServiceImpl.java
@@ -120,7 +120,9 @@ public class ExcelServiceImpl implements ExcelService {
 
             int rowNum = 1;
             for (InventarioLotes item : inventarioLotes) {
-                Inventario inv = item.getInventario();
+                Inventario inv = inventarioRepository
+                        .findByProductoAndSucursal(item.getProducto(), item.getSucursal())
+                        .orElse(null);
                 Integer cantidadActual = inv != null ? inv.getInventarioCantidadActual() : 0;
                 Integer cantidadMinima = inv != null ? inv.getInventarioCantidadMinima() : 0;
 

--- a/src/main/java/farmacias/AppOchoa/serviceimpl/VentaFelNotasCreditoServiceImpl.java
+++ b/src/main/java/farmacias/AppOchoa/serviceimpl/VentaFelNotasCreditoServiceImpl.java
@@ -1,17 +1,18 @@
 package farmacias.AppOchoa.serviceimpl;
 
+import farmacias.AppOchoa.dto.ventafel.VentaFelResponseDTO;
 import farmacias.AppOchoa.dto.ventafelnotascredito.VentaFelNotasCreditoCreateDTO;
 import farmacias.AppOchoa.dto.ventafelnotascredito.VentaFelNotasCreditoResponseDTO;
 import farmacias.AppOchoa.dto.ventafelnotascredito.VentaFelNotasCreditoSimpleDTO;
 import farmacias.AppOchoa.exception.ResourceNotFoundException;
-import farmacias.AppOchoa.model.NotaEstado;
-import farmacias.AppOchoa.model.Sucursal;
-import farmacias.AppOchoa.model.VentaFel;
-import farmacias.AppOchoa.model.VentaFelNotasCredito;
+import farmacias.AppOchoa.integracionfel.*;
+import farmacias.AppOchoa.model.*;
+import farmacias.AppOchoa.repository.CredencialesRepository;
 import farmacias.AppOchoa.repository.SucursalRepository;
 import farmacias.AppOchoa.repository.VentaFelNotasCreditoRepository;
 import farmacias.AppOchoa.repository.VentaFelRepository;
 import farmacias.AppOchoa.services.VentaFelNotasCreditoService;
+import farmacias.AppOchoa.util.EncryptionService;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -25,14 +26,32 @@ public class VentaFelNotasCreditoServiceImpl implements VentaFelNotasCreditoServ
     private final VentaFelNotasCreditoRepository ventaFelNotasCreditoRepository;
     private final VentaFelRepository ventaFelRepository;
     private final SucursalRepository sucursalRepository;
+    private final CredencialesRepository credencialesRepository;
+    private final EncryptionService encryptionService;
+    private final DteXmlNotaCreditoBuilder dteXmlNotaCreditoBuilder;
+    private final TekraSoapBuilder tekraSoapBuilder;
+    private final TekraClient tekraClient;
+    private final TekraResponseParser tekraResponseParser;
 
     public VentaFelNotasCreditoServiceImpl(
             VentaFelNotasCreditoRepository ventaFelNotasCreditoRepository,
             VentaFelRepository ventaFelRepository,
-            SucursalRepository sucursalRepository){
+            SucursalRepository sucursalRepository,
+            CredencialesRepository credencialesRepository,
+            EncryptionService encryptionService,
+            DteXmlNotaCreditoBuilder dteXmlNotaCreditoBuilder,
+            TekraSoapBuilder tekraSoapBuilder,
+            TekraClient tekraClient,
+            TekraResponseParser tekraResponseParser){
         this.ventaFelNotasCreditoRepository = ventaFelNotasCreditoRepository;
         this.ventaFelRepository = ventaFelRepository;
         this.sucursalRepository = sucursalRepository;
+        this.credencialesRepository = credencialesRepository;
+        this.encryptionService = encryptionService;
+        this.dteXmlNotaCreditoBuilder = dteXmlNotaCreditoBuilder;
+        this.tekraSoapBuilder = tekraSoapBuilder;
+        this.tekraClient = tekraClient;
+        this.tekraResponseParser = tekraResponseParser;
     }
 
     private Sucursal buscarSucursal(Long farmaciaId){
@@ -107,6 +126,48 @@ public class VentaFelNotasCreditoServiceImpl implements VentaFelNotasCreditoServ
     @Override
     public void eliminar(Long farmaciaId, Long id) {
         throw new UnsupportedOperationException("Por reglas de auditoría financiera, este registro es histórico y no puede ser eliminado ni modificado.");
+    }
+
+    @Override
+    public VentaFelNotasCreditoResponseDTO notaCredito(Long farmaciaId, Long id){
+        Sucursal sucursal = buscarSucursal(farmaciaId);
+        VentaFelNotasCredito ventaFelNotasCredito =  ventaFelNotasCreditoRepository.findByNotaIdAndSucursal_SucursalId(id, sucursal.getSucursalId())
+                .orElseThrow(() -> new ResourceNotFoundException("Documento no encontrado por ID"));
+
+        VentaFel ventaFel = ventaFelNotasCredito.getVentaFel();
+
+
+        CredencialesFel credencialesFel = credencialesRepository
+                .findBySucursal_SucursalIdAndAmbienteAndActivaTrue(sucursal.getSucursalId(), "pruebas")
+                .orElseThrow(() -> new ResourceNotFoundException("No hay credenciales FEL activas para esta sucursal"));
+
+        try{
+            String usuarioPlano = encryptionService.decrypt(credencialesFel.getCredencialUsuarioCifrado());
+            String clavePlano = encryptionService.decrypt(credencialesFel.getCredencialSecretoCifrado());
+
+            String dteXml = dteXmlNotaCreditoBuilder.construir(ventaFelNotasCredito.getVentaFel());
+            String sobreSoap = tekraSoapBuilder.construirSobre(credencialesFel, usuarioPlano, clavePlano, dteXml);
+            System.out.println(sobreSoap);
+            String respuestaSoap = tekraClient.certificar(sobreSoap);
+            System.out.println(respuestaSoap);
+            TekraCertificacionResultado resultado = tekraResponseParser.parsear(respuestaSoap);
+
+            if(resultado.isExitoso()){
+                ventaFelNotasCredito.setNotaEstado(NotaEstado.CERTIFICADA);
+                ventaFelNotasCredito.setNotaUuid(resultado.getUuid());
+                ventaFelNotasCredito.setNotaNumeroAutorizacion(resultado.getNumero());
+                ventaFelNotasCredito.setNotaXml(resultado.getXmlCertificado());
+
+            } else{
+                ventaFelNotasCredito.setNotaEstado(NotaEstado.ERROR);
+                ventaFelNotasCredito.setNotaMotivo(resultado.getMensajeError());
+            }
+        } catch (Exception e){
+            ventaFelNotasCredito.setNotaEstado(NotaEstado.ERROR);
+            ventaFelNotasCredito.setNotaMotivo("Error de comunicacion con TEKRA: " + e.getMessage());
+        }
+
+        return  VentaFelNotasCreditoResponseDTO.fromEntity(ventaFelNotasCreditoRepository.save(ventaFelNotasCredito));
     }
 
 }

--- a/src/main/java/farmacias/AppOchoa/serviceimpl/VentaFelServiceImpl.java
+++ b/src/main/java/farmacias/AppOchoa/serviceimpl/VentaFelServiceImpl.java
@@ -131,9 +131,7 @@ public class VentaFelServiceImpl implements VentaFelService {
 
             String dteXml = dteXmlBuilder.construir(venta);
             String sobreSoap = tekraSoapBuilder.construirSobre(credenciales, usuarioPlano, clavePlano, dteXml);
-            System.out.println(sobreSoap);
             String respuestaSoap = tekraClient.certificar(sobreSoap);
-            System.out.println(respuestaSoap);
             TekraCertificacionResultado resultado = tekraResponseParser.parsear(respuestaSoap);
 
             if (resultado.isExitoso()) {
@@ -192,9 +190,7 @@ public class VentaFelServiceImpl implements VentaFelService {
 
             String dteXml = dteXmlAnulacionBuilder.construir(ventaFel, motivo);
             String sobreSoap = tekraSoapBuilder.construirSobreAnulacion(credenciales, usuarioPlano,  clavePlano, dteXml);
-            System.out.println(sobreSoap);
             String respuestaSoap = tekraClient.anular(sobreSoap);
-            System.out.println(respuestaSoap);
             TekraCertificacionResultado resultado = tekraResponseParser.parsearAnulacion(respuestaSoap);
 
             if(resultado.isExitoso()) {

--- a/src/main/java/farmacias/AppOchoa/serviceimpl/VentaFelServiceImpl.java
+++ b/src/main/java/farmacias/AppOchoa/serviceimpl/VentaFelServiceImpl.java
@@ -3,22 +3,13 @@ package farmacias.AppOchoa.serviceimpl;
 import farmacias.AppOchoa.dto.ventafel.VentaFelCreateDTO;
 import farmacias.AppOchoa.dto.ventafel.VentaFelResponseDTO;
 import farmacias.AppOchoa.dto.ventafel.VentaFelSimpleDTO;
+import farmacias.AppOchoa.exception.BadRequestException;
 import farmacias.AppOchoa.exception.ResourceNotFoundException;
-import farmacias.AppOchoa.integracionfel.DteXmlBuilder;
-import farmacias.AppOchoa.integracionfel.TekraCertificacionResultado;
-import farmacias.AppOchoa.integracionfel.TekraClient;
-import farmacias.AppOchoa.integracionfel.TekraResponseParser;
-import farmacias.AppOchoa.integracionfel.TekraSoapBuilder;
-import farmacias.AppOchoa.model.CredencialesFel;
-import farmacias.AppOchoa.model.Sucursal;
-import farmacias.AppOchoa.model.Venta;
-import farmacias.AppOchoa.model.VentaFel;
-import farmacias.AppOchoa.model.VentaFelEstado;
-import farmacias.AppOchoa.repository.CredencialesRepository;
-import farmacias.AppOchoa.repository.SucursalRepository;
-import farmacias.AppOchoa.repository.VentaFelRepository;
-import farmacias.AppOchoa.repository.VentaRepository;
+import farmacias.AppOchoa.integracionfel.*;
+import farmacias.AppOchoa.model.*;
+import farmacias.AppOchoa.repository.*;
 import farmacias.AppOchoa.services.VentaFelService;
+import farmacias.AppOchoa.services.VentaService;
 import farmacias.AppOchoa.util.EncryptionService;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -33,32 +24,39 @@ public class VentaFelServiceImpl implements VentaFelService {
     private final VentaFelRepository ventaFelRepository;
     private final VentaRepository ventaRepository;
     private final SucursalRepository sucursalRepository;
+    private final VentaFelNotasCreditoRepository ventaFelNotasCreditoRepository;
     private final CredencialesRepository credencialesRepository;
     private final EncryptionService encryptionService;
     private final DteXmlBuilder dteXmlBuilder;
     private final TekraSoapBuilder tekraSoapBuilder;
     private final TekraClient tekraClient;
     private final TekraResponseParser tekraResponseParser;
+    private final DteXmlAnulacionBuilder dteXmlAnulacionBuilder;
+    private final VentaService ventaService;
 
     public VentaFelServiceImpl(
             VentaFelRepository ventaFelRepository,
             VentaRepository ventaRepository,
             SucursalRepository sucursalRepository,
+            VentaFelNotasCreditoRepository ventaFelNotasCreditoRepository,
             CredencialesRepository credencialesRepository,
             EncryptionService encryptionService,
             DteXmlBuilder dteXmlBuilder,
             TekraSoapBuilder tekraSoapBuilder,
             TekraClient tekraClient,
-            TekraResponseParser tekraResponseParser){
+            TekraResponseParser tekraResponseParser, DteXmlAnulacionBuilder dteXmlAnulacionBuilder, VentaService ventaService){
         this.ventaFelRepository = ventaFelRepository;
         this.ventaRepository = ventaRepository;
         this.sucursalRepository = sucursalRepository;
+        this.ventaFelNotasCreditoRepository = ventaFelNotasCreditoRepository;
         this.credencialesRepository = credencialesRepository;
         this.encryptionService = encryptionService;
         this.dteXmlBuilder = dteXmlBuilder;
         this.tekraSoapBuilder = tekraSoapBuilder;
         this.tekraClient = tekraClient;
         this.tekraResponseParser = tekraResponseParser;
+        this.dteXmlAnulacionBuilder = dteXmlAnulacionBuilder;
+        this.ventaService = ventaService;
     }
 
     private Sucursal buscarSucursal(Long farmaciaId){
@@ -133,7 +131,9 @@ public class VentaFelServiceImpl implements VentaFelService {
 
             String dteXml = dteXmlBuilder.construir(venta);
             String sobreSoap = tekraSoapBuilder.construirSobre(credenciales, usuarioPlano, clavePlano, dteXml);
+            System.out.println(sobreSoap);
             String respuestaSoap = tekraClient.certificar(sobreSoap);
+            System.out.println(respuestaSoap);
             TekraCertificacionResultado resultado = tekraResponseParser.parsear(respuestaSoap);
 
             if (resultado.isExitoso()) {
@@ -143,6 +143,8 @@ public class VentaFelServiceImpl implements VentaFelService {
                 ventaFel.setFelFechaCertificacion(OffsetDateTime.parse(resultado.getFechaCertificacion()).toLocalDateTime());
                 ventaFel.setFelXmlDte(resultado.getXmlCertificado());
                 ventaFel.setFelErrorDescripcion(null);
+                ventaFel.setFelSerie(resultado.getSerie());
+                ventaFel.setFelNumeroDocumento(resultado.getNumero());
             } else {
                 ventaFel.setFelEstado(VentaFelEstado.ERROR);
                 ventaFel.setFelErrorDescripcion(resultado.getMensajeError());
@@ -156,4 +158,61 @@ public class VentaFelServiceImpl implements VentaFelService {
 
         return VentaFelResponseDTO.fromEntity(ventaFelRepository.save(ventaFel));
     }
+
+
+    @Override
+    @Transactional
+    public VentaFelResponseDTO anular(Long farmaciaId, Long id, String motivo){
+        Sucursal sucursal = buscarSucursal(farmaciaId);
+        VentaFel ventaFel = ventaFelRepository.findByFelIdAndSucursal_SucursalId(id, sucursal.getSucursalId())
+                .orElseThrow(() -> new ResourceNotFoundException("Documento FEL no encontrado por ID"));
+
+        Venta venta = ventaFel.getVenta();
+
+        //Para anular ante tekra, se necesita el uuid de la factura.
+        //(el uuid solo existe si la factura se certificó)
+        if(ventaFel.getFelEstado() != VentaFelEstado.CERTIFICADA){
+            throw new BadRequestException("Solo se puede anular un documento certificado");
+        }
+
+        //Regla de negocio (No anular factura si esta misma ya cuenta con una nota de crédito)
+        if(ventaFelNotasCreditoRepository.existsByVentaFel_FelIdAndNotaEstado(id, NotaEstado.CERTIFICADA)){
+            throw new BadRequestException("La factura tiene nota de crédito, no puede anularse");
+        }
+
+        CredencialesFel credenciales = credencialesRepository
+                .findBySucursal_SucursalIdAndAmbienteAndActivaTrue(sucursal.getSucursalId(), "pruebas")
+                .orElseThrow(() -> new ResourceNotFoundException("No hay credenciales FEL activas en esta sucursal"));
+
+
+
+        try{
+            String usuarioPlano = encryptionService.decrypt(credenciales.getCredencialUsuarioCifrado());
+            String clavePlano = encryptionService.decrypt(credenciales.getCredencialSecretoCifrado());
+
+            String dteXml = dteXmlAnulacionBuilder.construir(ventaFel, motivo);
+            String sobreSoap = tekraSoapBuilder.construirSobreAnulacion(credenciales, usuarioPlano,  clavePlano, dteXml);
+            System.out.println(sobreSoap);
+            String respuestaSoap = tekraClient.anular(sobreSoap);
+            System.out.println(respuestaSoap);
+            TekraCertificacionResultado resultado = tekraResponseParser.parsearAnulacion(respuestaSoap);
+
+            if(resultado.isExitoso()) {
+                ventaFel.setFelEstado(VentaFelEstado.ANULADA);
+                ventaService.cambiarEstado(farmaciaId, venta.getVentaId(), VentaEstado.anulada);
+            }else {
+                ventaFel.setFelEstado(VentaFelEstado.ERROR);
+                ventaFel.setFelErrorDescripcion(resultado.getMensajeError());
+            }
+        }catch (Exception e) {
+            ventaFel.setFelEstado(VentaFelEstado.ERROR);
+            ventaFel.setFelErrorDescripcion("Error de comunicación con TEKRA: " + e.getMessage());
+        }
+        ventaFel.setFelIntentos(ventaFel.getFelIntentos() == null ? 1 : ventaFel.getFelIntentos() + 1);
+
+        return VentaFelResponseDTO.fromEntity(ventaFelRepository.save(ventaFel));
+
+
+    }
+
 }

--- a/src/main/java/farmacias/AppOchoa/serviceimpl/VentaServiceImpl.java
+++ b/src/main/java/farmacias/AppOchoa/serviceimpl/VentaServiceImpl.java
@@ -494,4 +494,6 @@ public class VentaServiceImpl implements VentaService {
         inventarioRepository.save(inventario);
     }
 
+
+
 }

--- a/src/main/java/farmacias/AppOchoa/services/VentaFelNotasCreditoService.java
+++ b/src/main/java/farmacias/AppOchoa/services/VentaFelNotasCreditoService.java
@@ -1,5 +1,6 @@
 package farmacias.AppOchoa.services;
 
+import farmacias.AppOchoa.dto.ventafel.VentaFelResponseDTO;
 import farmacias.AppOchoa.dto.ventafelnotascredito.VentaFelNotasCreditoCreateDTO;
 import farmacias.AppOchoa.dto.ventafelnotascredito.VentaFelNotasCreditoResponseDTO;
 import farmacias.AppOchoa.dto.ventafelnotascredito.VentaFelNotasCreditoSimpleDTO;
@@ -16,4 +17,5 @@ public interface VentaFelNotasCreditoService {
     Page<VentaFelNotasCreditoSimpleDTO> buscarPorFiltros(Long farmaciaId, NotaEstado estado, LocalDateTime fechaInicio, LocalDateTime fechaFin, Pageable pageable);
     Page<VentaFelNotasCreditoSimpleDTO> buscarPorTexto(Long farmaciaId, String texto, Pageable pageable);
     void eliminar(Long farmaciaId, Long id);
+    VentaFelNotasCreditoResponseDTO notaCredito(Long farmaciaId, Long id);
 }

--- a/src/main/java/farmacias/AppOchoa/services/VentaFelService.java
+++ b/src/main/java/farmacias/AppOchoa/services/VentaFelService.java
@@ -13,4 +13,5 @@ public interface VentaFelService {
     Page<VentaFelSimpleDTO> buscarPorTexto(Long farmaciaId, String texto, Pageable pageable);
     void eliminar(Long farmaciaId, Long id);
     VentaFelResponseDTO certificar(Long farmaciaId, Long id);
+    VentaFelResponseDTO anular(Long farmaciaId, Long id, String motivo);
 }

--- a/src/main/resources/application-qa.yml
+++ b/src/main/resources/application-qa.yml
@@ -1,0 +1,44 @@
+# Perfil QA: entorno de pruebas previo a produccion.
+# Usa una base de datos SEPARADA de prod (cluster QA), definida por env vars.
+# Se parece a prod (ddl-auto validate, Flyway manda el esquema) pero deja
+# Swagger y health details activos para poder verificar/depurar en QA.
+app:
+  cors:
+    # Sobreescribible por env var; permite el frontend de QA y localhost para pruebas.
+    allowed-origins: "${CORS_ALLOWED_ORIGINS:http://localhost:4200,http://localhost:3000}"
+
+spring:
+  jpa:
+    hibernate:
+      # validate como prod: el esquema lo controla Flyway, no Hibernate.
+      # Asi QA valida las mismas migraciones que iran a produccion.
+      ddl-auto: validate
+    show-sql: false
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: "health,info,prometheus,metrics"
+  endpoint:
+    health:
+      show-details: always
+
+logging:
+  level:
+    root: INFO
+    farmacias.AppOchoa: DEBUG
+    org.hibernate.SQL: OFF
+    org.hibernate.type.descriptor.sql.BasicBinder: OFF
+
+# En QA si dejamos Swagger para poder probar la API antes de prod.
+springdoc:
+  swagger-ui:
+    enabled: true
+  api-docs:
+    enabled: true
+
+loki:
+  url: ${LOKI_URL:}
+  username: ${LOKI_USERNAME:}
+  password: ${LOKI_PASSWORD:}

--- a/src/main/resources/db/migration/V19__agregar_columnas_fel_serie_numero_documento_fecha_emision.sql
+++ b/src/main/resources/db/migration/V19__agregar_columnas_fel_serie_numero_documento_fecha_emision.sql
@@ -1,0 +1,7 @@
+
+--Nuevas columnas (Complemento para funcionamiento de Tekra)
+
+ALTER TABLE ventas_fel
+    ADD COLUMN fel_serie VARCHAR(50)  NULL,
+    ADD COLUMN fel_numero_documento VARCHAR(50)  NULL,
+    ADD COLUMN fel_fecha_emision DATETIME NULL;

--- a/src/main/resources/db/migration/V20__permitir_null_nota_numero_autorizacion.sql
+++ b/src/main/resources/db/migration/V20__permitir_null_nota_numero_autorizacion.sql
@@ -1,0 +1,3 @@
+-- V20: permitir nota_numero_autorizacion NULL (se puebla solo al certificar, no al crear)
+ALTER TABLE ventas_fel_notas_credito
+    MODIFY nota_numero_autorizacion VARCHAR(50) NULL;

--- a/src/test/java/farmacias/AppOchoa/serviceImplTes/CompraServiceImplInventarioTest.java
+++ b/src/test/java/farmacias/AppOchoa/serviceImplTes/CompraServiceImplInventarioTest.java
@@ -6,15 +6,19 @@ import farmacias.AppOchoa.model.*;
 import farmacias.AppOchoa.repository.*;
 import farmacias.AppOchoa.serviceimpl.CompraServiceImpl;
 import farmacias.AppOchoa.services.KardexService;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 
 import java.math.BigDecimal;
@@ -22,19 +26,20 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
 
+/**
+ * Los @Mock replican EXACTAMENTE los 8 parámetros del constructor de
+ * CompraServiceImpl (compra, sucursal, usuario, producto, lote, inventario,
+ * farmacia, kardex). No hay CompraDetalleRepository: los detalles se persisten
+ * por cascada desde Compra.
+ */
 @ExtendWith(MockitoExtension.class)
-@DisplayName("CompraServiceImpl — sincronización de inventario agregado (M9)")
-public class CompraServiceImplInventarioTest {
-
-    private static final Long FARMACIA_ID = 1L;
-    private static final Long SUCURSAL_ID = 10L;
-    private static final Long PRODUCTO_ID = 100L;
-    private static final Long LOTE_ID = 1000L;
-    private static final Long USUARIO_ID = 5L;
+class CompraServiceImplInventarioTest {
 
     @Mock private CompraRepository compraRepository;
     @Mock private SucursalRepository sucursalRepository;
@@ -44,161 +49,195 @@ public class CompraServiceImplInventarioTest {
     @Mock private InventarioRepository inventarioRepository;
     @Mock private FarmaciaRepository farmaciaRepository;
     @Mock private KardexService kardexService;
-    @InjectMocks private CompraServiceImpl compraService;
+
+    @InjectMocks
+    private CompraServiceImpl compraService;
+
+    @Captor
+    private ArgumentCaptor<Inventario> inventarioCaptor;
 
     private Farmacia farmacia;
     private Sucursal sucursal;
     private Producto producto;
-    private Usuario usuario;
+    private Usuario solicitante;
 
     @BeforeEach
     void setUp() {
-        farmacia = new Farmacia();
-        farmacia.setFarmaciaId(FARMACIA_ID);
-        sucursal = new Sucursal();
-        sucursal.setSucursalId(SUCURSAL_ID);
-        sucursal.setFarmacia(farmacia);
-        producto = new Producto();
-        producto.setProductoId(PRODUCTO_ID);
-        producto.setFarmacia(farmacia);
-        producto.setSucursal(sucursal);
-        usuario = new Usuario();
-        usuario.setUsuarioId(USUARIO_ID);
-        usuario.setFarmacia(farmacia);
+        farmacia = Farmacia.builder().farmaciaId(1L).build();
 
-        SecurityContextHolder.getContext().setAuthentication(
-                new UsernamePasswordAuthenticationToken(usuario, null, java.util.Collections.emptyList()));
-    }
-
-    private void stubCrearComun() {
-        when(sucursalRepository.findByFarmacia_FarmaciaId(FARMACIA_ID))
-                .thenReturn(Optional.of(sucursal));
-        when(usuarioRepository.findByUsuarioIdAndFarmacia_FarmaciaId(USUARIO_ID, FARMACIA_ID))
-                .thenReturn(Optional.of(usuario));
-        when(farmaciaRepository.getReferenceById(FARMACIA_ID)).thenReturn(farmacia);
-        when(productoRepository.findById(PRODUCTO_ID)).thenReturn(Optional.of(producto));
-        when(compraRepository.save(any(Compra.class))).thenAnswer(a -> a.getArgument(0));
-    }
-
-    private CompraCreateDTO compraDto(int cantidad) {
-        CompraDetalleCreateDTO det = new CompraDetalleCreateDTO();
-        det.setProductoId(PRODUCTO_ID);
-        det.setCantidad(cantidad);
-        det.setPrecioUnitario(new BigDecimal("4.00"));
-        det.setNumeroLote("L-1");
-        det.setFechaVencimiento(LocalDate.now().plusYears(1));
-
-        CompraCreateDTO dto = new CompraCreateDTO();
-        dto.setSucursalId(SUCURSAL_ID);
-        dto.setFechaCompra(LocalDate.now());
-        dto.setDetalles(List.of(det));
-        return dto;
-    }
-
-    private InventarioLotes lote(int cantidad) {
-        InventarioLotes l = new InventarioLotes();
-        l.setLoteId(LOTE_ID);
-        l.setLoteNumero("L-1");
-        l.setLoteCantidadActual(cantidad);
-        l.setProducto(producto);
-        l.setSucursal(sucursal);
-        l.setFarmacia(farmacia);
-        return l;
-    }
-
-    @Test
-    @DisplayName("Comprar incrementa el inventario agregado existente")
-    void compraIncrementaInventarioExistente() {
-        stubCrearComun();
-        when(loteRepository.findByLoteNumeroAndSucursal_SucursalIdAndProducto_ProductoId("L-1", SUCURSAL_ID, PRODUCTO_ID))
-                .thenReturn(Optional.of(lote(20)));
-        Inventario inv = Inventario.builder()
-                .producto(producto).sucursal(sucursal).farmacia(farmacia)
-                .inventarioCantidadActual(20).inventarioCantidadMinima(5).build();
-        when(inventarioRepository.findByProductoYSucursalForUpdate(PRODUCTO_ID, SUCURSAL_ID))
-                .thenReturn(Optional.of(inv));
-
-        compraService.crear(FARMACIA_ID, compraDto(8));
-
-        assertEquals(28, inv.getInventarioCantidadActual());
-        verify(inventarioRepository).save(inv);
-    }
-
-    @Test
-    @DisplayName("Si no existe inventario agregado al comprar, se crea con mínima 0")
-    void compraCreaInventarioSiNoExiste() {
-        stubCrearComun();
-        when(loteRepository.findByLoteNumeroAndSucursal_SucursalIdAndProducto_ProductoId("L-1", SUCURSAL_ID, PRODUCTO_ID))
-                .thenReturn(Optional.empty());
-        when(inventarioRepository.findByProductoYSucursalForUpdate(PRODUCTO_ID, SUCURSAL_ID))
-                .thenReturn(Optional.empty());
-
-        compraService.crear(FARMACIA_ID, compraDto(8));
-
-        ArgumentCaptor<Inventario> captor = ArgumentCaptor.forClass(Inventario.class);
-        verify(inventarioRepository).save(captor.capture());
-        Inventario creado = captor.getValue();
-        assertEquals(8, creado.getInventarioCantidadActual());
-        assertEquals(0, creado.getInventarioCantidadMinima());
-        assertEquals(PRODUCTO_ID, creado.getProducto().getProductoId());
-        assertEquals(SUCURSAL_ID, creado.getSucursal().getSucursalId());
-        assertEquals(FARMACIA_ID, creado.getFarmacia().getFarmaciaId());
-    }
-
-    @Test
-    @DisplayName("Comprar setea la farmacia en la cabecera y en el lote nuevo")
-    void compraSeteaFarmaciaEnCabeceraYLoteNuevo() {
-        stubCrearComun();
-        // Lote inexistente: crear() debe construir uno nuevo con farmacia seteada
-        when(loteRepository.findByLoteNumeroAndSucursal_SucursalIdAndProducto_ProductoId("L-1", SUCURSAL_ID, PRODUCTO_ID))
-                .thenReturn(Optional.empty());
-        when(inventarioRepository.findByProductoYSucursalForUpdate(PRODUCTO_ID, SUCURSAL_ID))
-                .thenReturn(Optional.empty());
-
-        ArgumentCaptor<Compra> compraCaptor = ArgumentCaptor.forClass(Compra.class);
-        ArgumentCaptor<InventarioLotes> loteCaptor = ArgumentCaptor.forClass(InventarioLotes.class);
-
-        compraService.crear(FARMACIA_ID, compraDto(8));
-
-        verify(compraRepository).save(compraCaptor.capture());
-        assertNotNull(compraCaptor.getValue().getFarmacia(), "la cabecera Compra debe llevar farmacia");
-        assertEquals(FARMACIA_ID, compraCaptor.getValue().getFarmacia().getFarmaciaId());
-
-        verify(loteRepository).save(loteCaptor.capture());
-        assertNotNull(loteCaptor.getValue().getFarmacia(), "el lote nuevo debe llevar farmacia");
-        assertEquals(FARMACIA_ID, loteCaptor.getValue().getFarmacia().getFarmaciaId());
-    }
-
-    @Test
-    @DisplayName("Anular una compra activa decrementa el inventario agregado")
-    void anularCompraDecrementaInventario() {
-        CompraDetalle detalle = CompraDetalle.builder()
-                .detalleCantidad(8)
-                .loteId(lote(28))
-                .producto(producto)
-                .build();
-        Compra compra = Compra.builder()
-                .compraEstado(CompraEstado.activa)
-                .detalles(new java.util.ArrayList<>(List.of(detalle)))
-                .sucursal(sucursal)
+        sucursal = Sucursal.builder()
+                .sucursalId(10L)
                 .farmacia(farmacia)
                 .build();
 
-        when(sucursalRepository.findByFarmacia_FarmaciaId(FARMACIA_ID))
+        // buscarProducto() filtra por p.getSucursal().getSucursalId(): sin sucursal
+        // asignada el filter revienta con NPE antes de llegar al inventario.
+        producto = Producto.builder()
+                .productoId(100L)
+                .productoNombre("Acetaminofen 500mg")
+                .productoPrecioCompra(new BigDecimal("2.00"))
+                .productoPrecioVenta(new BigDecimal("5.00"))
+                .farmacia(farmacia)
+                .sucursal(sucursal)
+                .build();
+
+        // UsuarioSimpleDTO.fromEntity() concatena nombre + apellido al mapear la
+        // respuesta, por eso el usuario necesita esos campos poblados.
+        solicitante = Usuario.builder()
+                .usuarioId(7L)
+                .nombreUsuarioUsuario("jperez")
+                .usuarioNombre("Juan")
+                .usuarioApellido("Perez")
+                .farmacia(farmacia)
+                .build();
+
+        // crear() castea getPrincipal() a Usuario: el contexto debe llevar la entidad,
+        // no un String como en un token de autenticación por username.
+        Authentication auth = new UsernamePasswordAuthenticationToken(solicitante, null);
+        SecurityContextHolder.getContext().setAuthentication(auth);
+
+        when(sucursalRepository.findByFarmacia_FarmaciaId(1L))
                 .thenReturn(Optional.of(sucursal));
-        when(compraRepository.findByCompraIdAndSucursal_SucursalId(7L, SUCURSAL_ID))
-                .thenReturn(Optional.of(compra));
-        when(loteRepository.findByLoteIdAndSucursalIdForUpdate(LOTE_ID, SUCURSAL_ID))
-                .thenReturn(Optional.of(lote(28)));
-        Inventario inv = Inventario.builder()
-                .producto(producto).sucursal(sucursal).farmacia(farmacia)
-                .inventarioCantidadActual(28).inventarioCantidadMinima(0).build();
-        when(inventarioRepository.findByProductoYSucursalForUpdate(PRODUCTO_ID, SUCURSAL_ID))
-                .thenReturn(Optional.of(inv));
+        when(usuarioRepository.findByUsuarioIdAndFarmacia_FarmaciaId(7L, 1L))
+                .thenReturn(Optional.of(solicitante));
+        when(farmaciaRepository.getReferenceById(1L)).thenReturn(farmacia);
+        when(productoRepository.findById(100L)).thenReturn(Optional.of(producto));
 
-        compraService.cambiarEstado(FARMACIA_ID, 7L, CompraEstado.anulada);
+        // El lote se busca scopeado a numero+sucursal+producto; sin este stub el
+        // Optional es null y orElseGet() lanza NPE.
+        when(loteRepository.findByLoteNumeroAndSucursal_SucursalIdAndProducto_ProductoId(
+                anyString(), anyLong(), anyLong()))
+                .thenReturn(Optional.empty());
+        when(loteRepository.save(any(InventarioLotes.class)))
+                .thenAnswer(inv -> inv.getArgument(0));
 
-        assertEquals(20, inv.getInventarioCantidadActual());
-        verify(inventarioRepository).save(inv);
+        when(compraRepository.save(any(Compra.class)))
+                .thenAnswer(inv -> {
+                    Compra c = inv.getArgument(0);
+                    if (c.getCompraId() == null) c.setCompraId(500L);
+                    return c;
+                });
+    }
+
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
+    }
+
+    /**
+     * crear() NO usa findByProductoAndSucursal(entidad, entidad): obtenerInventarioConLock()
+     * llama findByProductoYSucursalForUpdate(productoId, sucursalId) con los IDs.
+     * Stubear el método equivocado dejaba el mock devolviendo null -> NPE en orElseGet().
+     */
+    private void stubInventarioExistente(Optional<Inventario> resultado) {
+        when(inventarioRepository.findByProductoYSucursalForUpdate(100L, 10L))
+                .thenReturn(resultado);
+    }
+
+    private CompraCreateDTO buildCompraDto(int cantidad, BigDecimal precio) {
+        CompraDetalleCreateDTO detalleDto = CompraDetalleCreateDTO.builder()
+                .productoId(100L)
+                .cantidad(cantidad)
+                .precioUnitario(precio)
+                .numeroLote("L-001")
+                .fechaVencimiento(LocalDate.now().plusMonths(6))
+                .build();
+
+        return CompraCreateDTO.builder()
+                .sucursalId(10L)
+                .fechaCompra(LocalDate.now())
+                .observaciones("Compra de prueba")
+                .detalles(List.of(detalleDto))
+                .build();
+    }
+
+    @Nested
+    @DisplayName("Si no existe inventario agregado al comprar")
+    class CuandoNoExisteInventario {
+
+        @Test
+        @DisplayName("Si no existe inventario agregado al comprar, se crea con mínima 0")
+        void seCreaInventarioConMinimaCero() {
+            stubInventarioExistente(Optional.empty());
+            // Inventario nuevo (inventarioId null) -> crear() lo persiste con saveAndFlush
+            // y reemplaza la entidad del mapa por la retornada.
+            when(inventarioRepository.saveAndFlush(any(Inventario.class)))
+                    .thenAnswer(inv -> inv.getArgument(0));
+            when(inventarioRepository.save(any(Inventario.class)))
+                    .thenAnswer(inv -> inv.getArgument(0));
+
+            CompraCreateDTO dto = buildCompraDto(20, new BigDecimal("5.00"));
+
+            compraService.crear(1L, dto);
+
+            verify(inventarioRepository).saveAndFlush(inventarioCaptor.capture());
+            Inventario creado = inventarioCaptor.getValue();
+
+            assertThat(creado.getInventarioCantidadMinima()).isEqualTo(0);
+            assertThat(creado.getProducto()).isEqualTo(producto);
+            assertThat(creado.getSucursal()).isEqualTo(sucursal);
+            assertThat(creado.getFarmacia()).isEqualTo(farmacia);
+
+            // saveAndFlush ocurre ANTES de sumar la cantidad (el captor guarda la
+            // referencia, así que se comprueba el estado final de la entidad).
+            assertThat(creado.getInventarioCantidadActual()).isEqualTo(20);
+        }
+
+        @Test
+        @DisplayName("Comprar setea la farmacia en la cabecera y en el lote nuevo")
+        void seteaFarmaciaEnCabeceraYLote() {
+            stubInventarioExistente(Optional.empty());
+            when(inventarioRepository.saveAndFlush(any(Inventario.class)))
+                    .thenAnswer(inv -> inv.getArgument(0));
+            when(inventarioRepository.save(any(Inventario.class)))
+                    .thenAnswer(inv -> inv.getArgument(0));
+
+            CompraCreateDTO dto = buildCompraDto(15, new BigDecimal("3.50"));
+
+            compraService.crear(1L, dto);
+
+            ArgumentCaptor<Compra> compraCaptor = ArgumentCaptor.forClass(Compra.class);
+            verify(compraRepository).save(compraCaptor.capture());
+            assertThat(compraCaptor.getValue().getFarmacia()).isEqualTo(farmacia);
+
+            ArgumentCaptor<InventarioLotes> loteCaptor = ArgumentCaptor.forClass(InventarioLotes.class);
+            verify(loteRepository).save(loteCaptor.capture());
+            InventarioLotes lote = loteCaptor.getValue();
+            assertThat(lote.getFarmacia()).isEqualTo(farmacia);
+            assertThat(lote.getSucursal()).isEqualTo(sucursal);
+            assertThat(lote.getLoteCantidadActual()).isEqualTo(15);
+        }
+    }
+
+    @Nested
+    @DisplayName("Si ya existe inventario agregado al comprar")
+    class CuandoYaExisteInventario {
+
+        @Test
+        @DisplayName("Comprar incrementa el inventario agregado existente")
+        void incrementaInventarioExistente() {
+            Inventario existente = Inventario.builder()
+                    .inventarioId(900L)
+                    .producto(producto)
+                    .sucursal(sucursal)
+                    .farmacia(farmacia)
+                    .inventarioCantidadActual(10)
+                    .inventarioCantidadMinima(5)
+                    .build();
+
+            stubInventarioExistente(Optional.of(existente));
+            when(inventarioRepository.save(any(Inventario.class)))
+                    .thenAnswer(inv -> inv.getArgument(0));
+
+            CompraCreateDTO dto = buildCompraDto(8, new BigDecimal("2.00"));
+
+            compraService.crear(1L, dto);
+
+            // Ya tiene inventarioId: no se re-crea, solo se actualiza con save().
+            verify(inventarioRepository, never()).saveAndFlush(any(Inventario.class));
+            verify(inventarioRepository).save(existente);
+            assertThat(existente.getInventarioCantidadActual()).isEqualTo(18);
+            assertThat(existente.getInventarioCantidadMinima()).isEqualTo(5);
+        }
     }
 }


### PR DESCRIPTION
- Add DteXmlNotaCreditoBuilder + VentaFelNotasCreditoServiceImpl.certificar() to certify credit notes (NCRE), including the ReferenciasNota complement linking back to the original invoice
- Add DteXmlAnulacionBuilder, TekraClient.anular(), TekraSoapBuilder.construirSobreAnulacion(), TekraResponseParser.parsearAnulacion() to support invoice cancellation with TEKRA
- VentaFelServiceImpl.anular(): blocks cancellation of invoices that already have a certified credit note; reverts stock via VentaServiceImpl.cambiarEstado() only after TEKRA confirms
- Fix CompraServiceImpl.obtenerInventarioConLock(): flush new Inventario row before inserting dependent lotes (FK violation on first purchase of a product)
- Fix CompraDetalle builder missing .sucursal()/.farmacia() assignment
- Remove broken double-mapped @JoinColumns association in InventarioLotes (caused getProducto() to return null when navigated via lote, breaking stock reversal on cancellation)
- ExcelServiceImpl: use InventarioRepository.findByProductoAndSucursal() instead of the removed item.getInventario()
- VentaFel: add felSerie, felNumeroDocumento, felFechaEmision
- Remove duplicate existsByVentaFel_FelIdAndNotaEstado from VentaFelRepository (belongs to VentaFelNotasCreditoRepository)
- DB: V19 (ventas_fel serie/numero_documento/fecha_emision), V20 (ventas_fel_notas_credito.nota_numero_autorizacion nullable)